### PR TITLE
Changes webpack build target to web.

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -110,6 +110,6 @@ module.exports = {
             }
         ]
     },
-    target: 'node',
+    target: 'web',
     externals: [nodeExternals()]
 };


### PR DESCRIPTION
When including lib built for target 'node' and using it on web projects compiled using server side rendering, builds break because lib dependencies are compiled to be used on node environment (inferring 'window' object references are not expected on node environment).
If lib is to be used on web assets, no need to compile for node usage.

This PR just changes the target from 'node' to 'web'.