### PR TITLE
Input as text only on summits without registration companies

### DIFF
--- a/src/components/inputs/registration-company-input.js
+++ b/src/components/inputs/registration-company-input.js
@@ -16,19 +16,14 @@ import PropTypes from 'prop-types'
 import AsyncSelect from 'react-select/lib/Async';
 import { queryRegistrationCompanies } from '../../utils/query-actions';
 
-const RegistrationCompanyInput = ({ error, value, onChange, id, multi, isMulti, className, summitId, onError, rawInput, ...rest }) => {
+const RegistrationCompanyInput = ({ error, value, onChange, id, multi, isMulti, className, summitId, onError, ...rest }) => {
 
     const [theValue, setTheValue] = useState({ value: null, label: '' });
     const [freeInput, setFreeInput] = useState(false);
     const [inputValue, setInputValue] = useState('');
     const [isMultiOptional, setIsMultiOptional] = useState(multi || isMulti);
     const [hasError, setHasError] = useState(error);
-
-    useEffect(() => {
-        if (rawInput) {
-            setFreeInput(true);
-        }
-    }, []);
+    const [noCompanies, setNoCompanies] = useState(false);
 
     useEffect(() => {
         setHasError(error);
@@ -109,6 +104,19 @@ const RegistrationCompanyInput = ({ error, value, onChange, id, multi, isMulti, 
 
         const translateOptions = (options) => {
 
+            // if the summit has no companies, set the input only as text
+            if (!input) {
+                if (options.length === 0) {
+                    setNoCompanies(true);
+                    setFreeInput(true);
+                } else {
+                    // if the input is empty, set only this option as default value
+                    const defaultOption = { value: null, label: 'Other' };
+                    callback([defaultOption]);
+                }
+                return;
+            }
+
             if (options instanceof Error) {
                 onError(options);
             }
@@ -137,7 +145,7 @@ const RegistrationCompanyInput = ({ error, value, onChange, id, multi, isMulti, 
                         style={{ paddingRight: 25 }}
                         {...rest}
                     />
-                    {!rawInput &&
+                    {!noCompanies &&
                         <i aria-label='Clear' style={{ position: 'absolute', top: 10, right: 25, cursor: 'pointer', opacity: '65%' }}
                             onClick={handleInputClear} className='fa fa-close'></i>
                     }
@@ -149,7 +157,7 @@ const RegistrationCompanyInput = ({ error, value, onChange, id, multi, isMulti, 
                     value={theValue.label && theValue.value ? theValue : null}
                     placeholder='Select a company'
                     onChange={handleChange}
-                    defaultOptions={[{ value: null, label: 'Other' }]}
+                    defaultOptions={true}
                     loadOptions={getCompanies}
                     isMulti={isMultiOptional}
                     className={className}

--- a/src/components/inputs/registration-company-input.js
+++ b/src/components/inputs/registration-company-input.js
@@ -24,10 +24,7 @@ const RegistrationCompanyInput = ({ error, value, onChange, id, multi, isMulti, 
     const [isMultiOptional, setIsMultiOptional] = useState(multi || isMulti);
     const [hasError, setHasError] = useState(error);
 
-    console.log('RegistrationCompanyInput', rawInput);
-
     useEffect(() => {
-        console.log('raw input', rawInput)
         if (rawInput) {
             setFreeInput(true);
         }

--- a/src/components/inputs/registration-company-input.js
+++ b/src/components/inputs/registration-company-input.js
@@ -16,7 +16,7 @@ import PropTypes from 'prop-types'
 import AsyncSelect from 'react-select/lib/Async';
 import { queryRegistrationCompanies } from '../../utils/query-actions';
 
-const RegistrationCompanyInput = ({ error, value, onChange, id, multi, isMulti, className, summitId, onError, ...rest }) => {
+const RegistrationCompanyInput = ({ error, value, onChange, id, multi, isMulti, className, summitId, onError, rawInput, ...rest }) => {
 
     const [theValue, setTheValue] = useState({ value: null, label: '' });
     const [freeInput, setFreeInput] = useState(false);
@@ -24,12 +24,21 @@ const RegistrationCompanyInput = ({ error, value, onChange, id, multi, isMulti, 
     const [isMultiOptional, setIsMultiOptional] = useState(multi || isMulti);
     const [hasError, setHasError] = useState(error);
 
+    console.log('RegistrationCompanyInput', rawInput);
+
+    useEffect(() => {
+        console.log('raw input', rawInput)
+        if (rawInput) {
+            setFreeInput(true);
+        }
+    }, []);
+
     useEffect(() => {
         setHasError(error);
     }, [error]);
 
     useEffect(() => {
-        if (!value.id && value.name) {            
+        if (!value.id && value.name) {
             setFreeInput(true);
             setInputValue(value.name);
             setTheValue({ value: null, label: value.name })
@@ -131,9 +140,11 @@ const RegistrationCompanyInput = ({ error, value, onChange, id, multi, isMulti, 
                         style={{ paddingRight: 25 }}
                         {...rest}
                     />
-                    <i aria-label='Clear' style={{ position: 'absolute', top: 10, right: 25, cursor: 'pointer', opacity: '65%' }}
-                        onClick={handleInputClear} className='fa fa-close'></i>
-                    
+                    {!rawInput &&
+                        <i aria-label='Clear' style={{ position: 'absolute', top: 10, right: 25, cursor: 'pointer', opacity: '65%' }}
+                            onClick={handleInputClear} className='fa fa-close'></i>
+                    }
+
                 </>
                 :
                 <AsyncSelect


### PR DESCRIPTION
* Adds a new prop to disable the dropdown component on client side.

ref: https://tipit.avaza.com/project/view/304272#!tab=task-pane&groupby=ProjectSection&view=vertical&task=2974830&fileview=grid

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>