### PR TITLE
Moving dropItem function from drop to end drag

### DIFF
--- a/src/components/table-sortable/SortableTableRow.js
+++ b/src/components/table-sortable/SortableTableRow.js
@@ -20,9 +20,6 @@ const SortableTableRow = ({ text, even, id, index, moveCard, dropItem, children 
                 handlerId: monitor.getHandlerId(),
             };
         },
-        drop(_item, monitor) {
-            return dropItem(id, index + 1)
-        },
         hover(item, monitor) {
             if (!refRow.current) {
                 return;
@@ -65,6 +62,9 @@ const SortableTableRow = ({ text, even, id, index, moveCard, dropItem, children 
         type: 'row',
         item: () => {
             return { id, index };
+        },
+        end:(_item, monitor) => {
+            return dropItem(id, index + 1)
         },
         collect: (monitor) => ({
             isDragging: monitor.isDragging(),


### PR DESCRIPTION
* Fix the bug when the item is dropped outside the container but the order is changed

ref: https://tipit.avaza.com/project/view#!tab=task-pane&groupby=MyTaskProject&view=vertical&task=3033893&fileview=grid

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>