### PR TITLE
RawHTML not replacing new lines with br tags as default

### DIFF
--- a/src/components/raw-html/index.js
+++ b/src/components/raw-html/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
-const RawHTML = ({children, className = ""}) =>
+const RawHTML = ({children, replaceNewLine = false, className = ""}) =>
     <span className={className}
-          dangerouslySetInnerHTML={{ __html: children?.replace(/\n/g, '<br />')}} />
+          dangerouslySetInnerHTML={{ __html: replaceNewLine ? children?.replace(/\n/g, '<br />') : children}} />
 
 export default RawHTML;


### PR DESCRIPTION
<img width="437" alt="image" src="https://user-images.githubusercontent.com/19543853/192893049-80cc10fa-ddfb-47b0-a2c7-a842d8b799d3.png">

ref: https://tipit.avaza.com/task#!sortby=DateUpdatedDesc&task=3053641

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com> 