### PR TITLE
Add new prop to trigger option reload of react-select component

### DIFF
--- a/src/components/simple-link-list/index.js
+++ b/src/components/simple-link-list/index.js
@@ -135,6 +135,7 @@ class SimpleLinkList extends React.Component {
                 <AsyncCreatableSelect
                     className="link-select btn-group text-left"
                     value={this.state.value}
+                    key={JSON.stringify(values)}
                     getOptionValue={option => option[valueKey]}
                     getOptionLabel={option => option[labelKey]}
                     onChange={this.handleChange}
@@ -149,6 +150,7 @@ class SimpleLinkList extends React.Component {
                 <AsyncSelect
                     className="link-select btn-group text-left"
                     value={this.state.value}
+                    key={JSON.stringify(values)}
                     getOptionValue={option => option[valueKey]}
                     getOptionLabel={option => option[labelKey]}
                     onChange={this.handleChange}


### PR DESCRIPTION
* Fix the bug that the dropdown shows options that are already on the table. The components re-renders but the dropdown isn't reloading their options. 
* Related to https://github.com/JedWatson/react-select/issues/1581#issuecomment-408625770

ref: https://tipit.avaza.com/task#!sortby=DateUpdatedDesc&task=3072749

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>