### PR TITLE
Adjusting styles to avoid div overlap on mobile resolutions

### DIFF
--- a/src/components/simple-link-list/index.js
+++ b/src/components/simple-link-list/index.js
@@ -165,7 +165,7 @@ class SimpleLinkList extends React.Component {
                 <div className="col-md-4 simple-link-list-title">
                     <h4>{title}</h4>
                 </div>
-                <div className="col-md pull-right btn-group">
+                <div className="col-md simple-link-list-buttons">
                     {AsyncComponent}
                     <button type="button" className="btn btn-default add-button" onClick={this.handleLink} disabled={disabledAdd}>
                         {T.translate("general.add")}

--- a/src/components/simple-link-list/simple-link-list.less
+++ b/src/components/simple-link-list/simple-link-list.less
@@ -13,6 +13,8 @@
 
 .simple-link-list {
   margin-top: 40px;
+  display: flex;
+  flex-direction: column;
   .link-select {
     width: 200px;
     .Select-control {
@@ -39,5 +41,9 @@
 .panel .simple-link-list {
   .simple-link-list-title {
     display: none;
+  }
+  .simple-link-list-buttons {
+    display: flex;
+    justify-content: flex-end;
   }
 }


### PR DESCRIPTION

<img width="1062" alt="image" src="https://github.com/OpenStackweb/openstack-uicore-foundation/assets/19543853/faac9056-d0e1-46e8-b094-a644da9205f0">

<img width="435" alt="image" src="https://github.com/OpenStackweb/openstack-uicore-foundation/assets/19543853/3d1ea932-adaa-4aab-a0c8-42eb03f55188">


ref: https://tipit.avaza.com/task#!sortby=DateUpdatedDesc&task=3347086

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>
