### PR TITLE
feat: add new mui formik color picker component

### DIFF
--- a/src/components/index.js
+++ b/src/components/index.js
@@ -83,6 +83,7 @@ export {TotalRow as MuiTotalRow, NotesRow as MuiNotesRow, FeeRow as MuiFeeRow, P
 export {default as MuiFormikAsyncSelect} from './mui/formik-inputs/mui-formik-async-select'
 export {default as MuiFormikCheckboxGroup} from './mui/formik-inputs/mui-formik-checkbox-group'
 export {default as MuiFormikCheckbox} from './mui/formik-inputs/mui-formik-checkbox'
+export {default as MuiFormikColorInput} from './mui/formik-inputs/mui-formik-color-input'
 export {default as MuiFormikDatepicker} from './mui/formik-inputs/mui-formik-datepicker'
 export {default as MuiFormikDiscountField} from './mui/formik-inputs/mui-formik-discountfield'
 export {default as MuiFormikDropdownCheckbox} from './mui/formik-inputs/mui-formik-dropdown-checkbox'

--- a/src/components/mui/__tests__/mui-formik-color-input.test.js
+++ b/src/components/mui/__tests__/mui-formik-color-input.test.js
@@ -1,0 +1,166 @@
+/**
+ * Copyright 2026 OpenStack Foundation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * */
+
+jest.mock("i18n-react/dist/i18n-react", () => ({
+  __esModule: true,
+  default: { translate: (key) => key }
+}));
+
+import React from "react";
+import { render, screen, fireEvent, act, waitFor } from "@testing-library/react";
+import { Formik, Form } from "formik";
+import "@testing-library/jest-dom";
+import MuiFormikColorInput from "../formik-inputs/mui-formik-color-input";
+
+const DEBOUNCE_MS = 250;
+const PLACEHOLDER_KEY = "color_picker.placeholder";
+
+const renderWithFormik = (props, initialValues = { testField: "" }) =>
+  render(
+    <Formik initialValues={initialValues} onSubmit={jest.fn()}>
+      <Form>
+        <MuiFormikColorInput name="testField" {...props} />
+      </Form>
+    </Formik>
+  );
+
+const renderWithSubmit = (initialValues = { testField: "" }, props = {}) => {
+  const onSubmit = jest.fn();
+  render(
+    <Formik initialValues={initialValues} onSubmit={onSubmit}>
+      <Form>
+        <MuiFormikColorInput name="testField" {...props} />
+        <button type="submit">Submit</button>
+      </Form>
+    </Formik>
+  );
+  return onSubmit;
+};
+
+// Restore real timers after each test to prevent leaking fake timers
+afterEach(() => jest.useRealTimers());
+
+const getColorInput = () => document.querySelector('input[type="color"]');
+
+describe("MuiFormikColorInput", () => {
+  test("renders a color input", () => {
+    renderWithFormik({});
+    expect(getColorInput()).toBeInTheDocument();
+  });
+
+  test("loads initial value: reflects value, shows clear button, hides placeholder", () => {
+    renderWithFormik({}, { testField: "#ff0000" });
+    expect(getColorInput()).toHaveValue("#ff0000");
+    expect(screen.getByRole("button")).toBeInTheDocument();
+    expect(screen.queryByText(PLACEHOLDER_KEY)).not.toBeInTheDocument();
+  });
+
+  test("empty initial state: shows placeholder and no clear button", () => {
+    renderWithFormik({});
+    expect(screen.getByText(PLACEHOLDER_KEY)).toBeInTheDocument();
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  test("blur without selection: formik value stays empty and placeholder remains", async () => {
+    const onSubmit = renderWithSubmit({ testField: "" });
+    const input = getColorInput();
+
+    fireEvent.focus(input);
+    fireEvent.blur(input);
+
+    expect(screen.getByText(PLACEHOLDER_KEY)).toBeInTheDocument();
+    fireEvent.click(screen.getByText("Submit"));
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith({ testField: "" }, expect.anything());
+    });
+  });
+
+  // The useEffect resets hasValue to false whenever localValue changes (before the debounce
+  // commits the new color to field.value). The clear button only appears after the debounce fires.
+  test("select a color: shows clear button and hides placeholder after debounce", () => {
+    jest.useFakeTimers();
+    renderWithFormik({});
+
+    fireEvent.change(getColorInput(), { target: { value: "#33aaff" } });
+    act(() => jest.advanceTimersByTime(DEBOUNCE_MS));
+
+    expect(screen.getByRole("button")).toBeInTheDocument();
+    expect(screen.queryByText(PLACEHOLDER_KEY)).not.toBeInTheDocument();
+  });
+
+  test("select a color: updates formik value after debounce", async () => {
+    jest.useFakeTimers();
+    const onSubmit = renderWithSubmit({ testField: "" });
+
+    fireEvent.change(getColorInput(), { target: { value: "#33aaff" } });
+    act(() => jest.advanceTimersByTime(DEBOUNCE_MS));
+    jest.useRealTimers();
+
+    fireEvent.click(screen.getByText("Submit"));
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith({ testField: "#33aaff" }, expect.anything());
+    });
+  });
+
+  test("clear button: shows placeholder and hides clear button", () => {
+    renderWithFormik({}, { testField: "#ff0000" });
+
+    fireEvent.click(screen.getByRole("button"));
+
+    expect(screen.getByText(PLACEHOLDER_KEY)).toBeInTheDocument();
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  test("clear button: resets formik value to empty", async () => {
+    const onSubmit = renderWithSubmit({ testField: "#ff0000" });
+
+    fireEvent.click(screen.getAllByRole("button")[0]);
+
+    fireEvent.click(screen.getByText("Submit"));
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith({ testField: "" }, expect.anything());
+    });
+  });
+
+  test("shows error message when field is touched and has an error", () => {
+    render(
+      <Formik
+        initialValues={{ testField: "" }}
+        initialErrors={{ testField: "Color is required" }}
+        initialTouched={{ testField: true }}
+        onSubmit={jest.fn()}
+      >
+        <Form>
+          <MuiFormikColorInput name="testField" />
+        </Form>
+      </Formik>
+    );
+    expect(screen.getByText("Color is required")).toBeInTheDocument();
+  });
+
+  test("does not show error when field is not yet touched", () => {
+    render(
+      <Formik
+        initialValues={{ testField: "" }}
+        initialErrors={{ testField: "Color is required" }}
+        initialTouched={{ testField: false }}
+        onSubmit={jest.fn()}
+      >
+        <Form>
+          <MuiFormikColorInput name="testField" />
+        </Form>
+      </Formik>
+    );
+    expect(screen.queryByText("Color is required")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/mui/formik-inputs/mui-formik-async-select.js
+++ b/src/components/mui/formik-inputs/mui-formik-async-select.js
@@ -31,7 +31,8 @@ const MuiFormikAsyncAutocomplete = ({
   formatOption = (item) => ({ value: item.id.toString(), label: item.name }),
   formatSelectedValue = null,
   queryParams = [],
-  isMulti = false
+  isMulti = false,
+  defaultOptions
 }) => {
   const [field, meta, helpers] = useField(name);
   const [options, setOptions] = useState([]);
@@ -58,7 +59,7 @@ const MuiFormikAsyncAutocomplete = ({
   };
 
   useEffect(() => {
-    if (searchTerm) {
+    if (!defaultOptions && searchTerm) {
       const delayDebounce = setTimeout(() => {
         fetchOptions(searchTerm);
       }, DEBOUNCE_WAIT_250);
@@ -99,7 +100,16 @@ const MuiFormikAsyncAutocomplete = ({
       fullWidth
       getOptionLabel={(option) => option.label || ""}
       isOptionEqualToValue={(option, value) => option.value === value.value}
-      onInputChange={(e, newInput) => setSearchTerm(newInput)}
+      onInputChange={!defaultOptions ? (e, newInput) => setSearchTerm(newInput) : undefined}
+      filterOptions={
+        // only apply filterOptions for "local" search
+        defaultOptions
+          ? (options, { inputValue }) =>
+            options.filter((opt) =>
+              opt.label.toLowerCase().includes(inputValue.toLowerCase())
+            )
+          : undefined
+      }
       renderInput={(params) => (
         <TextField
           {...params}

--- a/src/components/mui/formik-inputs/mui-formik-async-select.js
+++ b/src/components/mui/formik-inputs/mui-formik-async-select.js
@@ -107,7 +107,7 @@ const MuiFormikAsyncAutocomplete = ({
       fullWidth
       getOptionLabel={(option) => option.label || ""}
       isOptionEqualToValue={(option, value) => option.value === value.value}
-      onInputChange={!localFilter ? (e, newInput) => setSearchTerm(newInput) : undefined}
+      onInputChange={!localFilter ? (e, newInput) => setSearchTerm(newInput) : (x) => x}
       filterOptions={
         // only apply filterOptions for "local" search
         localFilter

--- a/src/components/mui/formik-inputs/mui-formik-async-select.js
+++ b/src/components/mui/formik-inputs/mui-formik-async-select.js
@@ -20,33 +20,25 @@ import {
 } from "@mui/material";
 import { useField } from "formik";
 import { DEBOUNCE_WAIT_250 } from "../../../utils/constants";
-import PropTypes from "prop-types";
 
-/**
- * Async Autocomplete with two modes:
- * - Remote (default): fetches options from API on each user input (debounced).
- * - Local (localFilter=true): fetches once on mount and filters options client-side.
- * Note: localFilter mode assumes stable queryParams (set once on mount).
- * If queryParams need to change, remount the component instead.
- */
 const MuiFormikAsyncAutocomplete = ({
   name,
   queryFunction,
+  multiple = false,
   placeholder = "Select...",
   plainValue = false,
   hiddenOptions = [],
   formatOption = (item) => ({ value: item.id.toString(), label: item.name }),
   formatSelectedValue = null,
   queryParams = [],
-  isMulti = false,
-  localFilter = false
+  isMulti = false
 }) => {
   const [field, meta, helpers] = useField(name);
   const [options, setOptions] = useState([]);
   const [loading, setLoading] = useState(false);
   const [searchTerm, setSearchTerm] = useState("");
 
-  const value = field.value || (isMulti ? [] : null);
+  const value = field.value || (multiple ? [] : null);
   const error = meta.touched && meta.error;
 
   const fetchOptions = async (input = "") => {
@@ -66,7 +58,7 @@ const MuiFormikAsyncAutocomplete = ({
   };
 
   useEffect(() => {
-    if (!localFilter && searchTerm) {
+    if (searchTerm) {
       const delayDebounce = setTimeout(() => {
         fetchOptions(searchTerm);
       }, DEBOUNCE_WAIT_250);
@@ -80,7 +72,7 @@ const MuiFormikAsyncAutocomplete = ({
   }, []);
 
   const handleChange = (event, selected) => {
-    if (!isMulti) {
+    if (!multiple) {
       const selectedValue = plainValue ? selected?.value || "" : selected;
       helpers.setValue(selectedValue);
       return;
@@ -89,10 +81,10 @@ const MuiFormikAsyncAutocomplete = ({
     const selectedItems = plainValue
       ? selected.map((s) => s.value)
       : selected.map((s) =>
-        formatSelectedValue
-          ? formatSelectedValue(s)
-          : { id: parseInt(s.value), name: s.label }
-      );
+          formatSelectedValue
+            ? formatSelectedValue(s)
+            : { id: parseInt(s.value), name: s.label }
+        );
 
     helpers.setValue(selectedItems);
   };
@@ -107,18 +99,7 @@ const MuiFormikAsyncAutocomplete = ({
       fullWidth
       getOptionLabel={(option) => option.label || ""}
       isOptionEqualToValue={(option, value) => option.value === value.value}
-      onInputChange={!localFilter ? (e, newInput) => setSearchTerm(newInput) : (x) => x}
-      filterOptions={
-        // only apply filterOptions for "local" search
-        localFilter
-          ? (options, { inputValue }) =>
-            options.filter((opt) =>
-              String(opt.label ?? "").toLowerCase().includes(
-                String(inputValue ?? "").toLowerCase()
-              )
-            )
-          : undefined
-      }
+      onInputChange={(e, newInput) => setSearchTerm(newInput)}
       renderInput={(params) => (
         <TextField
           {...params}
@@ -148,21 +129,12 @@ const MuiFormikAsyncAutocomplete = ({
       )}
       renderOption={(props, option, { selected }) => (
         <li {...props}>
-          {isMulti && <Checkbox checked={selected} sx={{ mr: 1 }} />}
+          {multiple && <Checkbox checked={selected} sx={{ mr: 1 }} />}
           {option.label}
         </li>
       )}
     />
   );
-};
-
-MuiFormikAsyncAutocomplete.propTypes = {
-  name: PropTypes.string.isRequired,
-  isMulti: PropTypes.bool,
-  queryFunction: PropTypes.func.isRequired,
-  formatOption: PropTypes.func,
-  queryParams: PropTypes.array,
-  localFilter: PropTypes.bool,
 };
 
 export default MuiFormikAsyncAutocomplete;

--- a/src/components/mui/formik-inputs/mui-formik-async-select.js
+++ b/src/components/mui/formik-inputs/mui-formik-async-select.js
@@ -32,7 +32,6 @@ import PropTypes from "prop-types";
 const MuiFormikAsyncAutocomplete = ({
   name,
   queryFunction,
-  multiple = false,
   placeholder = "Select...",
   plainValue = false,
   hiddenOptions = [],
@@ -47,7 +46,7 @@ const MuiFormikAsyncAutocomplete = ({
   const [loading, setLoading] = useState(false);
   const [searchTerm, setSearchTerm] = useState("");
 
-  const value = field.value || (multiple ? [] : null);
+  const value = field.value || (isMulti ? [] : null);
   const error = meta.touched && meta.error;
 
   const fetchOptions = async (input = "") => {
@@ -81,7 +80,7 @@ const MuiFormikAsyncAutocomplete = ({
   }, []);
 
   const handleChange = (event, selected) => {
-    if (!multiple) {
+    if (!isMulti) {
       const selectedValue = plainValue ? selected?.value || "" : selected;
       helpers.setValue(selectedValue);
       return;
@@ -90,10 +89,10 @@ const MuiFormikAsyncAutocomplete = ({
     const selectedItems = plainValue
       ? selected.map((s) => s.value)
       : selected.map((s) =>
-          formatSelectedValue
-            ? formatSelectedValue(s)
-            : { id: parseInt(s.value), name: s.label }
-        );
+        formatSelectedValue
+          ? formatSelectedValue(s)
+          : { id: parseInt(s.value), name: s.label }
+      );
 
     helpers.setValue(selectedItems);
   };
@@ -114,7 +113,9 @@ const MuiFormikAsyncAutocomplete = ({
         localFilter
           ? (options, { inputValue }) =>
             options.filter((opt) =>
-              opt.label.toLowerCase().includes(inputValue.toLowerCase())
+              String(opt.label ?? "").toLowerCase().includes(
+                String(inputValue ?? "").toLowerCase()
+              )
             )
           : undefined
       }
@@ -147,7 +148,7 @@ const MuiFormikAsyncAutocomplete = ({
       )}
       renderOption={(props, option, { selected }) => (
         <li {...props}>
-          {multiple && <Checkbox checked={selected} sx={{ mr: 1 }} />}
+          {isMulti && <Checkbox checked={selected} sx={{ mr: 1 }} />}
           {option.label}
         </li>
       )}
@@ -157,6 +158,7 @@ const MuiFormikAsyncAutocomplete = ({
 
 MuiFormikAsyncAutocomplete.propTypes = {
   name: PropTypes.string.isRequired,
+  isMulti: PropTypes.bool,
   queryFunction: PropTypes.func.isRequired,
   formatOption: PropTypes.func,
   queryParams: PropTypes.array,

--- a/src/components/mui/formik-inputs/mui-formik-async-select.js
+++ b/src/components/mui/formik-inputs/mui-formik-async-select.js
@@ -20,7 +20,15 @@ import {
 } from "@mui/material";
 import { useField } from "formik";
 import { DEBOUNCE_WAIT_250 } from "../../../utils/constants";
+import PropTypes from "prop-types";
 
+/**
+ * Async Autocomplete with two modes:
+ * - Remote (default): fetches options from API on each user input (debounced).
+ * - Local (localFilter=true): fetches once on mount and filters options client-side.
+ * Note: localFilter mode assumes stable queryParams (set once on mount).
+ * If queryParams need to change, remount the component instead.
+ */
 const MuiFormikAsyncAutocomplete = ({
   name,
   queryFunction,
@@ -32,7 +40,7 @@ const MuiFormikAsyncAutocomplete = ({
   formatSelectedValue = null,
   queryParams = [],
   isMulti = false,
-  defaultOptions
+  localFilter = false
 }) => {
   const [field, meta, helpers] = useField(name);
   const [options, setOptions] = useState([]);
@@ -59,7 +67,7 @@ const MuiFormikAsyncAutocomplete = ({
   };
 
   useEffect(() => {
-    if (!defaultOptions && searchTerm) {
+    if (!localFilter && searchTerm) {
       const delayDebounce = setTimeout(() => {
         fetchOptions(searchTerm);
       }, DEBOUNCE_WAIT_250);
@@ -100,10 +108,10 @@ const MuiFormikAsyncAutocomplete = ({
       fullWidth
       getOptionLabel={(option) => option.label || ""}
       isOptionEqualToValue={(option, value) => option.value === value.value}
-      onInputChange={!defaultOptions ? (e, newInput) => setSearchTerm(newInput) : undefined}
+      onInputChange={!localFilter ? (e, newInput) => setSearchTerm(newInput) : undefined}
       filterOptions={
         // only apply filterOptions for "local" search
-        defaultOptions
+        localFilter
           ? (options, { inputValue }) =>
             options.filter((opt) =>
               opt.label.toLowerCase().includes(inputValue.toLowerCase())
@@ -145,6 +153,14 @@ const MuiFormikAsyncAutocomplete = ({
       )}
     />
   );
+};
+
+MuiFormikAsyncAutocomplete.propTypes = {
+  name: PropTypes.string.isRequired,
+  queryFunction: PropTypes.func.isRequired,
+  formatOption: PropTypes.func,
+  queryParams: PropTypes.array,
+  localFilter: PropTypes.bool,
 };
 
 export default MuiFormikAsyncAutocomplete;

--- a/src/components/mui/formik-inputs/mui-formik-color-input.js
+++ b/src/components/mui/formik-inputs/mui-formik-color-input.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import PropTypes from "prop-types";
 import { TextField } from "@mui/material";
 import { useField } from "formik";
@@ -6,6 +6,10 @@ import { useField } from "formik";
 const MuiFormikColorInput = ({ name, ...rest }) => {
   const [field, meta, helpers] = useField(name);
   const [localValue, setLocalValue] = useState(field.value || "#000000");
+
+  useEffect(() => {
+    setLocalValue(field.value || "#000000");
+  }, [field.value]);
 
   const handleChange = (e) => {
     setLocalValue(e.target.value);

--- a/src/components/mui/formik-inputs/mui-formik-color-input.js
+++ b/src/components/mui/formik-inputs/mui-formik-color-input.js
@@ -1,0 +1,42 @@
+import React, { useState } from "react";
+import PropTypes from "prop-types";
+import { TextField } from "@mui/material";
+import { useField } from "formik";
+
+const MuiFormikColorInput = ({ name, ...rest }) => {
+  const [field, meta, helpers] = useField(name);
+  const [localValue, setLocalValue] = useState(field.value || "#000000");
+
+  const handleChange = (e) => {
+    setLocalValue(e.target.value);
+  };
+
+  const handleBlur = (e) => {
+    helpers.setValue(e.target.value);
+    helpers.setTouched(true);
+  };
+
+  return (
+    <TextField
+      type="color"
+      value={localValue}
+      onChange={handleChange}
+      onBlur={handleBlur}
+      error={meta.touched && Boolean(meta.error)}
+      helperText={meta.touched && meta.error}
+      fullWidth
+      sx={{
+        "& input[type='color']::-webkit-color-swatch-wrapper": {
+          padding: "2px",
+        }
+      }}
+      {...rest}
+    />
+  );
+};
+
+MuiFormikColorInput.propTypes = {
+  name: PropTypes.string.isRequired
+};
+
+export default MuiFormikColorInput;

--- a/src/components/mui/formik-inputs/mui-formik-color-input.js
+++ b/src/components/mui/formik-inputs/mui-formik-color-input.js
@@ -37,12 +37,16 @@ const MuiFormikColorInput = ({ name, placeholder = "Select a color", ...rest }) 
     if (debounceRef.current) {
       clearTimeout(debounceRef.current);
       debounceRef.current = null;
-      helpers.setValue(hasValue ? localValue : null);
+      helpers.setValue(hasValue ? localValue : "");
     }
   };
 
   const handleClear = (e) => {
     e.stopPropagation();
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+      debounceRef.current = null;
+    }
     setHasValue(false);
     helpers.setValue("");
     helpers.setTouched(true);

--- a/src/components/mui/formik-inputs/mui-formik-color-input.js
+++ b/src/components/mui/formik-inputs/mui-formik-color-input.js
@@ -5,7 +5,7 @@ import ClearIcon from "@mui/icons-material/Clear";
 import { useField } from "formik";
 import { DEBOUNCE_WAIT_150 } from "../../../utils/constants";
 
-const MuiFormikColorInput = ({ name, placeholder = "Select a color", ...rest }) => {
+const MuiFormikColorInput = ({ name, placeholder = "Select a color", InputProps: restInputProps, ...rest }) => {
   const [field, meta, helpers] = useField(name);
   const [hasValue, setHasValue] = useState(Boolean(field.value));
   const [localValue, setLocalValue] = useState(field.value || "#000000");
@@ -14,7 +14,7 @@ const MuiFormikColorInput = ({ name, placeholder = "Select a color", ...rest }) 
   useEffect(() => {
     setHasValue(Boolean(field.value));
     if (field.value && field.value !== localValue) setLocalValue(field.value);
-  }, [field.value]);
+  }, [field.value, localValue]);
 
   useEffect(() => () => {
     if (debounceRef.current) clearTimeout(debounceRef.current);
@@ -63,15 +63,17 @@ const MuiFormikColorInput = ({ name, placeholder = "Select a color", ...rest }) 
         error={meta.touched && Boolean(meta.error)}
         helperText={meta.touched && meta.error}
         fullWidth
-        InputProps={hasValue ? {
-          endAdornment: (
-            <InputAdornment position="end">
-              <IconButton size="small" onClick={handleClear} edge="end" disableRipple>
-                <ClearIcon fontSize="small" />
-              </IconButton>
-            </InputAdornment>
-          ),
-        } : undefined}
+        InputProps={{
+          ...(hasValue ? {
+            endAdornment: (
+              <InputAdornment position="end">
+                <IconButton size="small" onClick={handleClear} edge="end" disableRipple>
+                  <ClearIcon fontSize="small" />
+                </IconButton>
+              </InputAdornment>
+            ),
+          } : {}), ...restInputProps
+        }}
         sx={{
           "& input[type='color']::-webkit-color-swatch-wrapper": { padding: "2px" },
         }}

--- a/src/components/mui/formik-inputs/mui-formik-color-input.js
+++ b/src/components/mui/formik-inputs/mui-formik-color-input.js
@@ -1,26 +1,29 @@
 import React, { useEffect, useRef, useState } from "react";
 import PropTypes from "prop-types";
-import { TextField } from "@mui/material";
+import { Box, IconButton, InputAdornment, TextField } from "@mui/material";
+import ClearIcon from "@mui/icons-material/Clear";
 import { useField } from "formik";
 import { DEBOUNCE_WAIT_150 } from "../../../utils/constants";
 
-const MuiFormikColorInput = ({ name, ...rest }) => {
+const MuiFormikColorInput = ({ name, placeholder = "Select a color", ...rest }) => {
   const [field, meta, helpers] = useField(name);
+  const [hasValue, setHasValue] = useState(Boolean(field.value));
   const [localValue, setLocalValue] = useState(field.value || "#000000");
   const debounceRef = useRef(null);
 
   useEffect(() => {
-    if (field.value !== localValue) setLocalValue(field.value || "#000000");
+    setHasValue(Boolean(field.value));
+    if (field.value && field.value !== localValue) setLocalValue(field.value);
   }, [field.value]);
 
   useEffect(() => () => {
-    if (!field.value) helpers.setValue("#000000");
     if (debounceRef.current) clearTimeout(debounceRef.current);
   }, []);
 
   const handleChange = (e) => {
     const value = e.target.value;
     setLocalValue(value);
+    setHasValue(true);
     if (debounceRef.current) clearTimeout(debounceRef.current);
     debounceRef.current = setTimeout(() => {
       helpers.setValue(value);
@@ -34,32 +37,71 @@ const MuiFormikColorInput = ({ name, ...rest }) => {
     if (debounceRef.current) {
       clearTimeout(debounceRef.current);
       debounceRef.current = null;
-      helpers.setValue(localValue);
+      helpers.setValue(hasValue ? localValue : null);
     }
   };
 
+  const handleClear = (e) => {
+    e.stopPropagation();
+    setHasValue(false);
+    helpers.setValue("");
+    helpers.setTouched(true);
+  };
+
   return (
-    <TextField
-      type="color"
-      name={field.name}
-      value={localValue}
-      onChange={handleChange}
-      onBlur={handleBlur}
-      error={meta.touched && Boolean(meta.error)}
-      helperText={meta.touched && meta.error}
-      fullWidth
-      sx={{
-        "& input[type='color']::-webkit-color-swatch-wrapper": {
-          padding: "2px"
-        }
-      }}
-      {...rest}
-    />
+    <Box sx={{ position: "relative", width: "100%" }}>
+      <TextField
+        type="color"
+        name={field.name}
+        value={localValue}
+        onChange={handleChange}
+        onBlur={handleBlur}
+        error={meta.touched && Boolean(meta.error)}
+        helperText={meta.touched && meta.error}
+        fullWidth
+        InputProps={hasValue ? {
+          endAdornment: (
+            <InputAdornment position="end">
+              <IconButton size="small" onClick={handleClear} edge="end" disableRipple>
+                <ClearIcon fontSize="small" />
+              </IconButton>
+            </InputAdornment>
+          ),
+        } : undefined}
+        sx={{
+          "& input[type='color']::-webkit-color-swatch-wrapper": { padding: "2px" },
+        }}
+        {...rest}
+      />
+      {!hasValue && (
+        <Box
+          sx={{
+            position: "absolute",
+            top: 2,
+            left: 2,
+            right: 2,
+            bottom: 2,
+            borderRadius: "3px",
+            bgcolor: "background.paper",
+            pointerEvents: "none",
+            display: "flex",
+            alignItems: "center",
+            px: "14px",
+            gap: 1,
+          }}
+        >
+          <Box component="span" sx={{ color: "text.disabled" }}>
+            {placeholder}
+          </Box>
+        </Box>
+      )}
+    </Box>
   );
 };
 
 MuiFormikColorInput.propTypes = {
-  name: PropTypes.string.isRequired
+  name: PropTypes.string.isRequired,
+  placeholder: PropTypes.string
 };
 
 export default MuiFormikColorInput;

--- a/src/components/mui/formik-inputs/mui-formik-color-input.js
+++ b/src/components/mui/formik-inputs/mui-formik-color-input.js
@@ -1,11 +1,12 @@
 import React, { useEffect, useRef, useState } from "react";
+import T from "i18n-react";
 import PropTypes from "prop-types";
 import { Box, IconButton, InputAdornment, TextField } from "@mui/material";
 import ClearIcon from "@mui/icons-material/Clear";
 import { useField } from "formik";
-import { DEBOUNCE_WAIT_150 } from "../../../utils/constants";
+import { DEBOUNCE_WAIT_250 } from "../../../utils/constants";
 
-const MuiFormikColorInput = ({ name, placeholder = "Select a color", InputProps: restInputProps, ...rest }) => {
+const MuiFormikColorInput = ({ name, placeholder = T.translate("color_picker.placeholder"), InputProps: restInputProps, ...rest }) => {
   const [field, meta, helpers] = useField(name);
   const [hasValue, setHasValue] = useState(Boolean(field.value));
   const [localValue, setLocalValue] = useState(field.value || "#000000");
@@ -28,7 +29,7 @@ const MuiFormikColorInput = ({ name, placeholder = "Select a color", InputProps:
     debounceRef.current = setTimeout(() => {
       helpers.setValue(value);
       debounceRef.current = null;
-    }, DEBOUNCE_WAIT_150);
+    }, DEBOUNCE_WAIT_250);
   };
 
   const handleBlur = (e) => {

--- a/src/components/mui/formik-inputs/mui-formik-color-input.js
+++ b/src/components/mui/formik-inputs/mui-formik-color-input.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useRef, useState } from "react";
 import PropTypes from "prop-types";
 import { TextField } from "@mui/material";
 import { useField } from "formik";
@@ -6,23 +6,26 @@ import { useField } from "formik";
 const MuiFormikColorInput = ({ name, ...rest }) => {
   const [field, meta, helpers] = useField(name);
   const [localValue, setLocalValue] = useState(field.value || "#000000");
-
-  useEffect(() => {
-    setLocalValue(field.value || "#000000");
-  }, [field.value]);
+  const isDirtyRef = useRef(false);
 
   const handleChange = (e) => {
     setLocalValue(e.target.value);
+    isDirtyRef.current = true;
   };
 
   const handleBlur = (e) => {
-    helpers.setValue(e.target.value);
+    field.onBlur(e);
     helpers.setTouched(true);
+    if (isDirtyRef.current) {
+      helpers.setValue(localValue);
+      isDirtyRef.current = false;
+    }
   };
 
   return (
     <TextField
       type="color"
+      name={field.name}
       value={localValue}
       onChange={handleChange}
       onBlur={handleBlur}
@@ -31,7 +34,7 @@ const MuiFormikColorInput = ({ name, ...rest }) => {
       fullWidth
       sx={{
         "& input[type='color']::-webkit-color-swatch-wrapper": {
-          padding: "2px",
+          padding: "2px"
         }
       }}
       {...rest}

--- a/src/components/mui/formik-inputs/mui-formik-color-input.js
+++ b/src/components/mui/formik-inputs/mui-formik-color-input.js
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import PropTypes from "prop-types";
 import { TextField } from "@mui/material";
 import { useField } from "formik";
@@ -8,6 +8,15 @@ const MuiFormikColorInput = ({ name, ...rest }) => {
   const [field, meta, helpers] = useField(name);
   const [localValue, setLocalValue] = useState(field.value || "#000000");
   const debounceRef = useRef(null);
+
+  useEffect(() => {
+    if (field.value !== localValue) setLocalValue(field.value || "#000000");
+  }, [field.value]);
+
+  useEffect(() => () => {
+    if (!field.value) helpers.setValue("#000000");
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+  }, []);
 
   const handleChange = (e) => {
     const value = e.target.value;

--- a/src/components/mui/formik-inputs/mui-formik-color-input.js
+++ b/src/components/mui/formik-inputs/mui-formik-color-input.js
@@ -2,23 +2,30 @@ import React, { useRef, useState } from "react";
 import PropTypes from "prop-types";
 import { TextField } from "@mui/material";
 import { useField } from "formik";
+import { DEBOUNCE_WAIT_150 } from "../../../utils/constants";
 
 const MuiFormikColorInput = ({ name, ...rest }) => {
   const [field, meta, helpers] = useField(name);
   const [localValue, setLocalValue] = useState(field.value || "#000000");
-  const isDirtyRef = useRef(false);
+  const debounceRef = useRef(null);
 
   const handleChange = (e) => {
-    setLocalValue(e.target.value);
-    isDirtyRef.current = true;
+    const value = e.target.value;
+    setLocalValue(value);
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      helpers.setValue(value);
+      debounceRef.current = null;
+    }, DEBOUNCE_WAIT_150);
   };
 
   const handleBlur = (e) => {
     field.onBlur(e);
     helpers.setTouched(true);
-    if (isDirtyRef.current) {
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+      debounceRef.current = null;
       helpers.setValue(localValue);
-      isDirtyRef.current = false;
     }
   };
 

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -138,5 +138,8 @@
     "total": "Total",
     "rate": "Rate",
     "action": "Action"
+  },
+  "color_picker": {
+    "placeholder": "Select a color"
   }
 }

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -7,6 +7,7 @@ export const BPS = 100;
 
 export const CODE_200 = 200;
 
+export const DEBOUNCE_WAIT_150 = 150;
 export const DEBOUNCE_WAIT_250 = 250;
 export const DEBOUNCE_WAIT = 500;
 

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -108,6 +108,7 @@ module.exports = {
         'components/mui/formik-inputs/async-select': './src/components/mui/formik-inputs/mui-formik-async-select.js',
         'components/mui/formik-inputs/checkbox-group': './src/components/mui/formik-inputs/mui-formik-checkbox-group.js',
         'components/mui/formik-inputs/checkbox': './src/components/mui/formik-inputs/mui-formik-checkbox.js',
+        'components/mui/formik-inputs/color-input': './src/components/mui/formik-inputs/mui-formik-color-input.js',
         'components/mui/formik-inputs/datepicker': './src/components/mui/formik-inputs/mui-formik-datepicker.js',
         'components/mui/formik-inputs/discount-field': './src/components/mui/formik-inputs/mui-formik-discountfield.js',
         'components/mui/formik-inputs/dropdown-checkbox': './src/components/mui/formik-inputs/mui-formik-dropdown-checkbox.js',


### PR DESCRIPTION
ref: https://app.clickup.com/t/86b9n7p5w
* fix: add prop to fetch only initial options on async-select

<img width="925" height="598" alt="image" src="https://github.com/user-attachments/assets/6ad2cdb0-cdc5-404f-a18e-46bfb6448df3" />
<img width="923" height="469" alt="image" src="https://github.com/user-attachments/assets/a5fa9019-6c1d-44fa-9b01-6b0cd1d4de79" />


Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Async select: optional local filtering for fast, case-insensitive client-side matching (reduces remote lookups).
  * Async select: improved multi-select selection and display behavior for more consistent formatting.
  * Formik color input: new color picker with local edit state, debounced commits, commit-on-blur, clear control, validation display, and color swatch.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenStackweb/openstack-uicore-foundation/pull/231?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->