### PR TITLE
Fix: remove components translations

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "openstack-uicore-foundation",
-    "version": "5.0.16",
+    "version": "5.0.18-beta.1",
     "description": "ui reactjs components for openstack marketing site",
     "main": "lib/openstack-uicore-foundation.js",
     "scripts": {

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,7 +1,3 @@
-import React from 'react';
-import T from 'i18n-react';
-import { getCurrentUserLanguage } from '../utils/methods';
-
 export {default as AjaxLoader} from './ajaxloader';
 export {default as RawHTML} from './raw-html';
 export {default as FreeTextSearch} from './free-text-search';
@@ -131,20 +127,3 @@ export {default as MuiUploadDialog} from './mui/UploadDialog'
 // export {default as MuiStripePayment} from './mui/StripePayment'                   // @stripe/react-stripe-js, @stripe/stripe-js
 // export {default as MuiAdditionalInput} from './mui/formik-inputs/additional-input/additional-input' // react-beautiful-dnd (via dnd-list)
 // export {default as MuiAdditionalInputList} from './mui/formik-inputs/additional-input/additional-input-list' // react-beautiful-dnd (via dnd-list)
-
-let language = getCurrentUserLanguage();
-
-// language would be something like es-ES or es_ES
-// However we store our files with format es.json or en.json
-// therefore retrieve only the first 2 digits
-
-if (language.length > 2) {
-    language = language.split("-")[0];
-    language = language.split("_")[0];
-}
-
-try {
-    T.setTexts(require(`../i18n/${language}.json`));
-} catch (e) {
-    T.setTexts(require(`../i18n/en.json`));
-}


### PR DESCRIPTION
https://app.clickup.com/t/86b9ry738

The setTexts in barrel export /components/index.js creates a conflict with host app setTexts and overrides the translations when lazy loading. 

in order to merge the two translation files (host app + uicore) we should use setAppTexts provided by uicore

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 5.0.18-beta.1

* **Refactor**
  * Streamlined component module initialization by removing setup operations at import time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->