### PR TITLE
fix: add allowedExtensions prop into formik upload component

### DIFF
--- a/src/components/mui/formik-inputs/mui-formik-upload.js
+++ b/src/components/mui/formik-inputs/mui-formik-upload.js
@@ -27,7 +27,8 @@ const MuiFormikUpload = ({
   id,
   name,
   onDelete,
-  maxFiles = MAX_INVENTORY_IMAGES_UPLOAD_QTY
+  maxFiles = MAX_INVENTORY_IMAGES_UPLOAD_QTY,
+  allowedExtensions
 }) => {
   const [field, meta, helpers] = useField(name);
 
@@ -35,7 +36,7 @@ const MuiFormikUpload = ({
     max_size: MAX_INVENTORY_IMAGE_UPLOAD_SIZE,
     max_uploads_qty: maxFiles,
     type: {
-      allowed_extensions: ALLOWED_INVENTORY_IMAGE_FORMATS
+      allowed_extensions: allowedExtensions || ALLOWED_INVENTORY_IMAGE_FORMATS
     }
   };
 
@@ -108,7 +109,8 @@ MuiFormikUpload.propTypes = {
   id: PropTypes.string,
   name: PropTypes.string.isRequired,
   onDelete: PropTypes.func,
-  maxFiles: PropTypes.number
+  maxFiles: PropTypes.number,
+  allowedExtensions: PropTypes.arrayOf(PropTypes.string)
 };
 
 export default MuiFormikUpload;


### PR DESCRIPTION
ref: https://app.clickup.com/t/86b9c38wj

<img width="930" height="277" alt="image" src="https://github.com/user-attachments/assets/b600a9c6-ec59-460d-a9ab-1aa19bab8e92" />

<img width="941" height="196" alt="image" src="https://github.com/user-attachments/assets/8f92ffc4-7c71-43f1-a05b-533cbd8089b3" />


Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added customizable image file extension support for uploads
  * Added configurable file upload limits to control the maximum number of files per upload session

<!-- end of auto-generated comment: release notes by coderabbit.ai -->