### PR TITLE
fix(company-input-v2): commit typed/autofilled value on blur

### DIFF
--- a/src/components/inputs/company-input-v2.js
+++ b/src/components/inputs/company-input-v2.js
@@ -56,6 +56,7 @@ const CompanyInputV2 = ({ summitId, isRequired, sx, onChange, id, name, label, v
       name={name}
       options={options}
       autoComplete
+      autoSelect
       freeSolo
       includeInputInList
       filterSelectedOptions
@@ -81,6 +82,10 @@ const CompanyInputV2 = ({ summitId, isRequired, sx, onChange, id, name, label, v
             id: 0,
             name: newValue.inputValue
           };
+        }
+        // autoSelect commits the raw typed/autofilled string on blur; normalize to {id, name}.
+        if (typeof tmpValue === "string" && tmpValue.trim()) {
+          tmpValue = { id: 0, name: tmpValue.trim() };
         }
         setOptions(tmpValue ? [tmpValue, ...options] : options);
         let ev = {


### PR DESCRIPTION
ref: https://app.clickup.com/t/86b9rnr4r

## Summary

`CompanyInputV2` wraps MUI Autocomplete in `freeSolo` mode, but `onChange` only fires when the user explicitly selects an option. Values entered via typing-and-tabbing or browser autofill (notably **iOS Chrome**) never propagate to the parent, so required-field validation fails on submit.

Reproduce with autofill simulation in DevTools: set the input value via the native setter, dispatch `input`, then blur — without this PR the parent's `company` stays `{id: null, name: ""}`; with it the parent receives `{id: 0, name: <typed>}`.

## Changes

- **Add `autoSelect`** to the Autocomplete. MUI's intended mechanism for committing the current input value on blur in a free-text combo.
- **Normalize strings in `onChange`** to the `{id, name}` shape consumers expect, since `autoSelect` calls `onChange` with the raw typed/autofilled string.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved company input field to properly normalize manually typed values, including automatic whitespace trimming and consistent formatting when input changes occur.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenStackweb/openstack-uicore-foundation/pull/241?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->