### PR TITLE
fix: improve SnackbarNotification cleanup

### DIFF
--- a/src/components/mui/SnackbarNotification/index.js
+++ b/src/components/mui/SnackbarNotification/index.js
@@ -42,20 +42,21 @@ const SnackbarNotification = ({
   const messageContext = useMemo(() => ({ successMessage, errorMessage }), []);
 
   const clearMessage = () => {
-    setMsgData({});
     clearSnackbarMessage();
+    setMsgData({});
   };
 
   const onClose = () => {
     setOpen(false);
-    setTimeout(clearMessage, NOTIFICATION_TIMEOUT);
+  };
+
+  const handleExited = () => {
+    clearMessage();
   };
 
   useEffect(() => {
     if (!empty(msgData.html)) {
       setOpen(true);
-    } else {
-      setOpen(false);
     }
   }, [msgData]);
 
@@ -71,6 +72,7 @@ const SnackbarNotification = ({
       <Snackbar
         open={open}
         onClose={onClose}
+        onExited={handleExited}
         anchorOrigin={{ vertical: "top", horizontal: "center" }}
         autoHideDuration={NOTIFICATION_TIMEOUT}
       >


### PR DESCRIPTION
ref: https://app.clickup.com/t/86b9y6h89

**Rationale**

Previously, the SnackbarNotification component sometimes rendered a second, empty snackbar (with only the icon) after the intended message disappeared. This was caused by the cleanup logic: when the snackbar message was cleared, the component briefly rendered with empty content before unmounting, due to the timing of state updates and the use of setTimeout.

This change improves the cleanup flow by leveraging the Snackbar’s onExited event, which fires only after the exit animation completes (either after autoHideDuration or manual close). Now, the message state is cleared only after the snackbar is fully closed, preventing any intermediate render with empty content. This ensures a smoother user experience and eliminates redundant or empty snackbar displays.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced notification handling to ensure messages clear reliably after notifications finish transitioning out.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenStackweb/openstack-uicore-foundation/pull/244?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->