### PR TITLE
test(company-input-v2): pull api callback from mock call args to avoid CI race

### DIFF
--- a/src/components/inputs/__tests__/company-input-v2.test.js
+++ b/src/components/inputs/__tests__/company-input-v2.test.js
@@ -207,10 +207,7 @@ describe("CompanyInputV2 integration", () => {
 
     it("auto-replaces a free-text commit with the canonical match when the API response arrives after blur", () => {
         // Withhold the API callback to simulate the network being slower than blur.
-        let resolveQuery;
-        queryRegistrationCompanies.mockImplementation((_summitId, _input, cb) => {
-            resolveQuery = cb;
-        });
+        queryRegistrationCompanies.mockImplementation(() => {});
 
         const onChange = jest.fn();
         // Start with the free-text commit already in place (what happens when
@@ -221,8 +218,14 @@ describe("CompanyInputV2 integration", () => {
         // Type to populate inputValue so the effect kicks in.
         fireEvent.change(input, { target: { value: "tipit" } });
 
+        // Pull the captured callback from the mock's most recent call rather
+        // than via a closure variable: avoids races where the effect hasn't
+        // committed by the time we try to resolve it.
+        expect(queryRegistrationCompanies).toHaveBeenCalled();
+        const [, , cb] = queryRegistrationCompanies.mock.calls[queryRegistrationCompanies.mock.calls.length - 1];
+
         // Now the response arrives with the canonical option.
-        act(() => { resolveQuery([{ id: 1, name: "Tipit" }]); });
+        act(() => { cb([{ id: 1, name: "Tipit" }]); });
 
         // The component should have called onChange with the canonical option.
         const promoted = onChange.mock.calls


### PR DESCRIPTION
Same test-stability fix that was applied to the v5 port (PR #250). The original `auto-replaces a free-text commit…` test from #246 captures the API callback via a closure variable that gets set inside the mock implementation; the closure is read on the next line, which races against React's effect commit timing. Passes locally, can flake in CI under different timing.

Pulling the callback directly from `mock.calls[last][2]` makes the test deterministic.