### PR TITLE
Fix: global qty field prevent negatives

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "openstack-uicore-foundation",
-    "version": "5.0.25-beta.0",
+    "version": "5.0.25-beta.1",
     "description": "ui reactjs components for openstack marketing site",
     "main": "lib/openstack-uicore-foundation.js",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "openstack-uicore-foundation",
-    "version": "5.0.24",
+    "version": "5.0.25-beta.0",
     "description": "ui reactjs components for openstack marketing site",
     "main": "lib/openstack-uicore-foundation.js",
     "scripts": {

--- a/src/components/mui/FormItemTable/__tests__/GlobalQuantityField.test.js
+++ b/src/components/mui/FormItemTable/__tests__/GlobalQuantityField.test.js
@@ -12,7 +12,8 @@
  * */
 
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, act, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { Formik, Form } from "formik";
 import "@testing-library/jest-dom";
 import GlobalQuantityField from "../components/GlobalQuantityField";
@@ -20,9 +21,9 @@ import GlobalQuantityField from "../components/GlobalQuantityField";
 const row = { form_item_id: 1, quantity_limit_per_sponsor: 5 };
 const fieldName = `i-${row.form_item_id}-c-global-f-quantity`;
 
-const renderField = (props = {}) =>
+const renderField = (props = {}, onSubmit = jest.fn()) =>
   render(
-    <Formik initialValues={{ [fieldName]: 0 }} onSubmit={jest.fn()}>
+    <Formik initialValues={{ [fieldName]: 0 }} onSubmit={onSubmit}>
       <Form>
         <GlobalQuantityField
           row={row}
@@ -30,6 +31,7 @@ const renderField = (props = {}) =>
           value={0}
           {...props}
         />
+        <button type="submit">submit</button>
       </Form>
     </Formik>
   );
@@ -60,5 +62,82 @@ describe("GlobalQuantityField", () => {
     renderField({ extraColumns: [{ type: "Text" }] });
     const input = screen.getByRole("spinbutton");
     expect(input).not.toHaveAttribute("readonly");
+  });
+
+  test("clamps value to quantity_limit_per_sponsor when user types above it", async () => {
+    const onSubmit = jest.fn();
+    renderField({}, onSubmit);
+    const input = screen.getByRole("spinbutton");
+    const submitButton = screen.getByText("submit");
+    await act(async () => {
+      fireEvent.change(input, { target: { value: "10" } });
+      await userEvent.click(submitButton);
+    });
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({ [fieldName]: 5 }),
+      expect.anything()
+    );
+  });
+
+  test("resets to 0 (not silent no-op) when field is cleared", async () => {
+    const onSubmit = jest.fn();
+    renderField({ value: 5 }, onSubmit);
+    const input = screen.getByRole("spinbutton");
+    const submitButton = screen.getByText("submit");
+    await act(async () => {
+      fireEvent.change(input, { target: { value: "" } });
+      await userEvent.click(submitButton);
+    });
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({ [fieldName]: 0 }),
+      expect.anything()
+    );
+  });
+
+  test("stays at 0 (not negative) when down-arrow decrements from 0", async () => {
+    const onSubmit = jest.fn();
+    renderField({}, onSubmit);
+    const input = screen.getByRole("spinbutton");
+    const submitButton = screen.getByText("submit");
+    await act(async () => {
+      fireEvent.change(input, { target: { value: "-1" } });
+      await userEvent.click(submitButton);
+    });
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({ [fieldName]: 0 }),
+      expect.anything()
+    );
+  });
+
+  test("clamps all values to 0 when quantity_limit_per_sponsor is 0", async () => {
+    const onSubmit = jest.fn();
+    const zeroLimitRow = { ...row, quantity_limit_per_sponsor: 0 };
+    renderField({ row: zeroLimitRow }, onSubmit);
+    const input = screen.getByRole("spinbutton");
+    const submitButton = screen.getByText("submit");
+    await act(async () => {
+      fireEvent.change(input, { target: { value: "3" } });
+      await userEvent.click(submitButton);
+    });
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({ [fieldName]: 0 }),
+      expect.anything()
+    );
+  });
+
+  test("does not apply upper bound when quantity_limit_per_sponsor is undefined", async () => {
+    const onSubmit = jest.fn();
+    const unlimitedRow = { form_item_id: 1 };
+    renderField({ row: unlimitedRow }, onSubmit);
+    const input = screen.getByRole("spinbutton");
+    const submitButton = screen.getByText("submit");
+    await act(async () => {
+      fireEvent.change(input, { target: { value: "100" } });
+      await userEvent.click(submitButton);
+    });
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({ [fieldName]: 100 }),
+      expect.anything()
+    );
   });
 });

--- a/src/components/mui/FormItemTable/components/GlobalQuantityField.js
+++ b/src/components/mui/FormItemTable/components/GlobalQuantityField.js
@@ -36,11 +36,10 @@ const GlobalQuantityField = ({
 
   const handleChange = (e) => {
     const val = parseInt(e.target.value, 10);
+    if (isNaN(val)) { helpers.setValue(0); return; }
     const max = row.quantity_limit_per_sponsor;
-    if (!isNaN(val)) {
-      const clamped = max !== undefined ? Math.min(Math.max(val, 0), max) : Math.max(val, 0);
-      helpers.setValue(clamped);
-    }
+    const clamped = max !== undefined ? Math.min(Math.max(val, 0), max) : Math.max(val, 0);
+    helpers.setValue(clamped);
   };
 
   return (

--- a/src/components/mui/FormItemTable/components/GlobalQuantityField.js
+++ b/src/components/mui/FormItemTable/components/GlobalQuantityField.js
@@ -34,6 +34,15 @@ const GlobalQuantityField = ({
     helpers.setTouched(true);
   }, [value]);
 
+  const handleChange = (e) => {
+    const val = parseInt(e.target.value, 10);
+    const max = row.quantity_limit_per_sponsor;
+    if (!isNaN(val)) {
+      const clamped = max !== undefined ? Math.min(Math.max(val, 0), max) : Math.max(val, 0);
+      helpers.setValue(clamped);
+    }
+  };
+
   return (
     <MuiFormikTextField
       name={name}
@@ -41,6 +50,7 @@ const GlobalQuantityField = ({
       size="small"
       type="number"
       disabled={disabled}
+      onChange={handleChange}
       slotProps={{
         htmlInput: {
           readOnly: isReadOnly,

--- a/src/components/mui/FormItemTable/index.js
+++ b/src/components/mui/FormItemTable/index.js
@@ -128,36 +128,36 @@ const FormItemTable = ({
       <Table>
         <TableHead>
           <TableRow sx={{ backgroundColor: "#EAEDF4" }}>
-            <TableCell>
+            <TableCell sx={{ minWidth: 40 }}>
               {T.translate("sponsor_edit_form.code")}
             </TableCell>
-            <TableCell>
+            <TableCell sx={{ minWidth: 120 }}>
               {T.translate("sponsor_edit_form.description")}
             </TableCell>
             <TableCell sx={{ minWidth: 120 }}>
               {T.translate("sponsor_edit_form.custom_rate")}
             </TableCell>
-            <TableCell>
+            <TableCell sx={{ minWidth: 40 }}>
               {T.translate("sponsor_edit_form.early_bird_rate")}
             </TableCell>
-            <TableCell>
+            <TableCell sx={{ minWidth: 40 }}>
               {T.translate("sponsor_edit_form.standard_rate")}
             </TableCell>
-            <TableCell>
+            <TableCell sx={{ minWidth: 40 }}>
               {T.translate("sponsor_edit_form.onsite_rate")}
             </TableCell>
             {extraColumns.map((exc) => (
-              <TableCell key={`colhead-${exc.type_id}`}>{exc.name}</TableCell>
+              <TableCell key={`colhead-${exc.type_id}`} sx={{ minWidth: 200 }}>{exc.name}</TableCell>
             ))}
             <TableCell sx={{ minWidth: 120 }}>
               {T.translate("sponsor_edit_form.qty")}
             </TableCell>
             <TableCell sx={{ minWidth: 40 }} />
             {/* item level extra field */}
-            <TableCell sx={{ minWidth: 120 }}>
+            <TableCell sx={{ minWidth: 40 }}>
               {T.translate("sponsor_edit_form.total")}
             </TableCell>
-            <TableCell sx={{ minWidth: 120 }}>
+            <TableCell sx={{ minWidth: 40 }}>
               {T.translate("sponsor_edit_form.notes")}
             </TableCell>
           </TableRow>
@@ -208,7 +208,6 @@ const FormItemTable = ({
               {extraColumns.map((exc) => (
                 <TableCell
                   key={`datacell-${row.form_item_id}-${exc.type_id}`}
-                  sx={{ minWidth: 200 }}
                 >
                   <ItemTableField
                     field={exc}

--- a/src/components/mui/__tests__/mui-formik-quantity-field.test.js
+++ b/src/components/mui/__tests__/mui-formik-quantity-field.test.js
@@ -100,6 +100,82 @@ describe("MuiFormikQuantityField", () => {
     );
   });
 
+  it("must reset to 0 when field is cleared", async () => {
+    const onSubmit = jest.fn();
+
+    renderWithFormik({ label: "some field", onSubmit }, { testField: 5 });
+
+    const field = screen.getByLabelText("some field");
+    const submitButton = screen.getByText("submit");
+    await act(async () => {
+      fireEvent.change(field, { target: { value: "" } });
+      await userEvent.click(submitButton);
+    });
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({ testField: 0 }),
+      expect.anything()
+    );
+  });
+
+  it("must clamp to 0 when down-arrow decrements below min", async () => {
+    const onSubmit = jest.fn();
+
+    renderWithFormik({ label: "some field", onSubmit }, { testField: 0 });
+
+    const field = screen.getByLabelText("some field");
+    const submitButton = screen.getByText("submit");
+    await act(async () => {
+      fireEvent.change(field, { target: { value: "-1" } });
+      await userEvent.click(submitButton);
+    });
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({ testField: 0 }),
+      expect.anything()
+    );
+  });
+
+  it("must clamp all typed values to 0 when max is 0", async () => {
+    const onSubmit = jest.fn();
+
+    renderWithFormik(
+      { label: "some field", max: 0, onSubmit },
+      { testField: 0 }
+    );
+
+    const field = screen.getByLabelText("some field");
+    const submitButton = screen.getByText("submit");
+    await act(async () => {
+      fireEvent.change(field, { target: { value: "5" } });
+      await userEvent.click(submitButton);
+    });
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({ testField: 0 }),
+      expect.anything()
+    );
+  });
+
+  it("must not apply upper bound when max is not provided", async () => {
+    const onSubmit = jest.fn();
+
+    renderWithFormik({ label: "some field", onSubmit }, { testField: 0 });
+
+    const field = screen.getByLabelText("some field");
+    const submitButton = screen.getByText("submit");
+    await act(async () => {
+      await userEvent.clear(field);
+      await userEvent.type(field, "9999");
+      await userEvent.click(submitButton);
+    });
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({ testField: 9999 }),
+      expect.anything()
+    );
+  });
+
   it("must clamp value to max when max is provided", async () => {
     const onSubmit = jest.fn();
 

--- a/src/components/mui/__tests__/mui-formik-quantity-field.test.js
+++ b/src/components/mui/__tests__/mui-formik-quantity-field.test.js
@@ -12,7 +12,7 @@
  * */
 
 import React from "react";
-import { render, screen, act } from "@testing-library/react";
+import { render, screen, act, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Formik, Form } from "formik";
 import "@testing-library/jest-dom";
@@ -74,6 +74,52 @@ describe("MuiFormikQuantityField", () => {
     expect(onSubmit).toHaveBeenCalledWith(
       expect.objectContaining({
         testField: 12345
+      }),
+      expect.anything()
+    );
+  });
+
+  it("must not allow value below 0", async () => {
+    const onSubmit = jest.fn();
+
+    renderWithFormik({ label: "some field", onSubmit }, { testField: 0 });
+
+    const field = screen.getByLabelText("some field");
+
+    const submitButton = screen.getByText("submit");
+    await act(async () => {
+      fireEvent.change(field, { target: { value: "-1" } });
+      await userEvent.click(submitButton);
+    });
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        testField: 0
+      }),
+      expect.anything()
+    );
+  });
+
+  it("must clamp value to max when max is provided", async () => {
+    const onSubmit = jest.fn();
+
+    renderWithFormik(
+      { label: "some field", max: 10, onSubmit },
+      { testField: 0 }
+    );
+
+    const field = screen.getByLabelText("some field");
+
+    const submitButton = screen.getByText("submit");
+    await act(async () => {
+      await userEvent.clear(field);
+      await userEvent.type(field, "99");
+      await userEvent.click(submitButton);
+    });
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        testField: 10
       }),
       expect.anything()
     );

--- a/src/components/mui/formik-inputs/mui-formik-quantity-field.js
+++ b/src/components/mui/formik-inputs/mui-formik-quantity-field.js
@@ -23,11 +23,10 @@ const MuiFormikQuantityField = ({ name, min, max, ...props }) => {
 
   const handleChange = (e) => {
     const val = parseInt(e.target.value, 10);
-    if (!isNaN(val)) {
-      const effectiveMin = min ?? 0;
-      const clamped = max != null ? Math.min(Math.max(val, effectiveMin), max) : Math.max(val, effectiveMin);
-      helpers.setValue(clamped);
-    }
+    const effectiveMin = min ?? 0;
+    if (isNaN(val)) { helpers.setValue(effectiveMin); return; }
+    const clamped = max != null ? Math.min(Math.max(val, effectiveMin), max) : Math.max(val, effectiveMin);
+    helpers.setValue(clamped);
   };
 
   return (

--- a/src/components/mui/formik-inputs/mui-formik-quantity-field.js
+++ b/src/components/mui/formik-inputs/mui-formik-quantity-field.js
@@ -13,27 +13,45 @@
 
 import React from "react";
 import PropTypes from "prop-types";
+import { useField } from "formik";
 import MuiFormikTextField from "./mui-formik-textfield";
 
 const BLOCKED_KEYS = ["e", "E", "+", "-"];
 
-const MuiFormikQuantityField = ({ ...props }) => (
-  <MuiFormikTextField
-    type="number"
-    onKeyDown={(e) => {
-      if (BLOCKED_KEYS.includes(e.key)) {
-        e.nativeEvent.preventDefault();
-        e.nativeEvent.stopImmediatePropagation();
-      }
-    }}
-    inputProps={{
-      min: 0,
-      inputMode: "numeric"
-    }}
-    // eslint-disable-next-line react/jsx-props-no-spreading
-    {...props}
-  />
-);
+const MuiFormikQuantityField = ({ name, min, max, ...props }) => {
+  const [, , helpers] = useField(name);
+
+  const handleChange = (e) => {
+    const val = parseInt(e.target.value, 10);
+    if (!isNaN(val)) {
+      const effectiveMin = min ?? 0;
+      const clamped = max != null ? Math.min(Math.max(val, effectiveMin), max) : Math.max(val, effectiveMin);
+      helpers.setValue(clamped);
+    }
+  };
+
+  return (
+    <MuiFormikTextField
+      name={name}
+      type="number"
+      onKeyDown={(e) => {
+        if (BLOCKED_KEYS.includes(e.key)) {
+          e.nativeEvent.preventDefault();
+          e.nativeEvent.stopImmediatePropagation();
+        }
+      }}
+      onChange={handleChange}
+      slotProps={{
+        htmlInput: {
+          min: min ?? 0,
+          ...(max != null ? { max } : {})
+        }
+      }}
+      // eslint-disable-next-line react/jsx-props-no-spreading
+      {...props}
+    />
+  );
+};
 
 MuiFormikQuantityField.propTypes = {
   name: PropTypes.string.isRequired,


### PR DESCRIPTION
When clicking down arrow on a globalQuantityField ,the app crashes. This PR is to prevent down arrow click on a GlobalQuantityField when value is 0. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Quantity inputs now validate user input, prevent negative entries, reset cleared fields to 0, and clamp values to configured per-item limits when present.

* **Bug Fixes**
  * Table column sizing for item rows and headers standardized for more consistent layout.

* **Tests**
  * Expanded test coverage for quantity behavior, clamping, and reset cases.

* **Chores**
  * Updated package version to 5.0.25-beta.1.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenStackweb/openstack-uicore-foundation/pull/255?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->