### PR TITLE
fix: add image preview and download link for upload input v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -169,7 +169,7 @@
             "src/**/*.{js,jsx,mjs}"
         ],
         "moduleNameMapper": {
-            "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/__mocks__/fileMock.js",
+            "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/src/__mocks__/fileMock.js",
             "\\.(css|scss)$": "identity-obj-proxy"
         },
         "testMatch": [

--- a/src/components/inputs/upload-input-v3/__tests__/upload-input-v3.test.js
+++ b/src/components/inputs/upload-input-v3/__tests__/upload-input-v3.test.js
@@ -31,6 +31,19 @@ jest.mock('../dropzone-v3', () => ({
   },
 }));
 
+jest.mock('i18n-react/dist/i18n-react', () => {
+  const en = require('../../../../i18n/en.json');
+  return {
+    __esModule: true,
+    default: {
+      translate: (key) => {
+        const value = key.split('.').reduce((obj, part) => obj?.[part], en);
+        return value ?? key;
+      }
+    }
+  };
+});
+
 describe('UploadInputV3', () => {
   const defaultProps = {
     value: [],

--- a/src/components/inputs/upload-input-v3/__tests__/upload-input-v3.test.js
+++ b/src/components/inputs/upload-input-v3/__tests__/upload-input-v3.test.js
@@ -288,6 +288,52 @@ describe('UploadInputV3', () => {
     });
   });
 
+  describe('File Preview and Download', () => {
+    test('renders a preview image linked to the file', () => {
+      const files = [{ filename: 'image.png', size: 102400, public_url: 'https://cdn.example.com/image.png' }];
+      render(<UploadInputV3 {...defaultProps} value={files} />);
+      const img = screen.getByRole('img', { name: 'image.png' });
+      expect(img).toHaveAttribute('src', 'https://cdn.example.com/image.png');
+      const previewLink = img.closest('a');
+      expect(previewLink).toHaveAttribute('href', 'https://cdn.example.com/image.png');
+      expect(previewLink).toHaveAttribute('target', '_blank');
+      expect(previewLink).not.toHaveAttribute('download');
+    });
+
+    test('prefers private_url and falls back to public_url when private_url is "#"', () => {
+      const { rerender } = render(<UploadInputV3 {...defaultProps} value={[{
+        filename: 'a.png', size: 1024,
+        private_url: 'https://private.example.com/a.png',
+        public_url: 'https://cdn.example.com/a.png',
+      }]} />);
+      expect(screen.getByRole('img', { name: 'a.png' })).toHaveAttribute('src', 'https://private.example.com/a.png');
+
+      rerender(<UploadInputV3 {...defaultProps} value={[{
+        filename: 'a.png', size: 1024,
+        private_url: '#',
+        public_url: 'https://cdn.example.com/a.png',
+      }]} />);
+      expect(screen.getByRole('img', { name: 'a.png' })).toHaveAttribute('src', 'https://cdn.example.com/a.png');
+    });
+
+    test('filename is a download link with correct href', () => {
+      const files = [{ filename: 'document.pdf', size: 102400, public_url: 'https://cdn.example.com/document.pdf' }];
+      const { container } = render(<UploadInputV3 {...defaultProps} value={files} />);
+      const downloadLink = container.querySelector('a[download]');
+      expect(downloadLink).toHaveAttribute('href', 'https://cdn.example.com/document.pdf');
+      expect(downloadLink).toHaveAttribute('target', '_blank');
+      expect(downloadLink).toHaveTextContent('document.pdf');
+    });
+
+    test('preview image falls back to file_icon on load error', () => {
+      const files = [{ filename: 'document.pdf', size: 102400, public_url: 'https://cdn.example.com/document.pdf' }];
+      render(<UploadInputV3 {...defaultProps} value={files} />);
+      const img = screen.getByRole('img', { name: 'document.pdf' });
+      fireEvent.error(img);
+      expect(img).not.toHaveAttribute('src', 'https://cdn.example.com/document.pdf');
+    });
+  });
+
   describe('Edge Cases', () => {
     test('handles empty value array', () => {
       const { container } = render(<UploadInputV3 {...defaultProps} value={[]} />);

--- a/src/components/inputs/upload-input-v3/__tests__/upload-input-v3.test.js
+++ b/src/components/inputs/upload-input-v3/__tests__/upload-input-v3.test.js
@@ -293,7 +293,6 @@ describe('UploadInputV3', () => {
       const files = [{ filename: 'image.png', size: 102400, public_url: 'https://cdn.example.com/image.png' }];
       render(<UploadInputV3 {...defaultProps} value={files} />);
       const img = screen.getByRole('img', { name: 'image.png' });
-      expect(img).toHaveAttribute('src', 'https://cdn.example.com/image.png');
       const previewLink = img.closest('a');
       expect(previewLink).toHaveAttribute('href', 'https://cdn.example.com/image.png');
       expect(previewLink).toHaveAttribute('target', '_blank');
@@ -301,19 +300,19 @@ describe('UploadInputV3', () => {
     });
 
     test('prefers private_url and falls back to public_url when private_url is "#"', () => {
-      const { rerender } = render(<UploadInputV3 {...defaultProps} value={[{
+      const { rerender, container } = render(<UploadInputV3 {...defaultProps} value={[{
         filename: 'a.png', size: 1024,
         private_url: 'https://private.example.com/a.png',
         public_url: 'https://cdn.example.com/a.png',
       }]} />);
-      expect(screen.getByRole('img', { name: 'a.png' })).toHaveAttribute('src', 'https://private.example.com/a.png');
+      expect(container.querySelector('a[download]')).toHaveAttribute('href', 'https://private.example.com/a.png');
 
       rerender(<UploadInputV3 {...defaultProps} value={[{
         filename: 'a.png', size: 1024,
         private_url: '#',
         public_url: 'https://cdn.example.com/a.png',
       }]} />);
-      expect(screen.getByRole('img', { name: 'a.png' })).toHaveAttribute('src', 'https://cdn.example.com/a.png');
+      expect(container.querySelector('a[download]')).toHaveAttribute('href', 'https://cdn.example.com/a.png');
     });
 
     test('filename is a download link with correct href', () => {

--- a/src/components/inputs/upload-input-v3/index.js
+++ b/src/components/inputs/upload-input-v3/index.js
@@ -12,6 +12,7 @@
  **/
 
 import React, { useState, useRef, useMemo, useCallback, useEffect } from 'react';
+import T from "i18n-react/dist/i18n-react";
 import {
   Box,
   Typography,
@@ -205,14 +206,14 @@ const UploadInputV3 = ({
     if (!postUrl) {
       return (
         <Alert severity="error" sx={{ borderRadius: 2 }}>
-          No Post URL
+          {T.translate("upload_input_v3.no_post_url")}
         </Alert>
       );
     }
     if (!canAdd) {
       return (
         <Alert severity="warning" sx={{ borderRadius: 2 }}>
-          Upload has been disabled by administrators.
+          {T.translate("upload_input_v3.upload_disabled")}
         </Alert>
       );
     }
@@ -238,7 +239,7 @@ const UploadInputV3 = ({
         <Box className="dz-custom-content">
           <UploadFileIcon className="dz-custom-icon" />
           <Typography variant="body2" className="dz-custom-message">
-            <span className="dz-click-text">Click to upload</span> or drag and drop
+            <span className="dz-click-text">{T.translate("upload_input_v3.click_upload")}</span> {T.translate("upload_input_v3.drag_and_drop")}
           </Typography>
           {(extDisplay || maxSize) && (
             <Typography variant="caption" className="dz-custom-hint">
@@ -384,7 +385,7 @@ const UploadInputV3 = ({
                 sx={fileRowSx}
               >
                 <Box sx={{ display: 'flex', alignItems: 'center', mr: 2, width: 64, height: 64, flexShrink: 0 }}>
-                  <a href={src} target="_blank" title="See Preview">
+                  <a href={src} target="_blank" title={T.translate("upload_input_v3.see_preview")}>
                     <ProgressiveImg
                       alt={filename}
                       src={previewSrc}
@@ -399,7 +400,7 @@ const UploadInputV3 = ({
                     href={src}
                     target="_blank"
                     rel="noreferrer"
-                    title="Preview file"
+                    title={T.translate("upload_input_v3.preview_file")}
                     download
                     variant="body2"
                     fontWeight={500}
@@ -408,7 +409,7 @@ const UploadInputV3 = ({
                     {filename}
                   </Typography>
                   <Typography variant="caption" color="text.secondary">
-                    {fileSize} · Complete
+                    {fileSize} · {T.translate("upload_input_v3.complete")}
                   </Typography>
                 </Box>
 

--- a/src/components/inputs/upload-input-v3/index.js
+++ b/src/components/inputs/upload-input-v3/index.js
@@ -25,6 +25,7 @@ import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import ErrorOutlineIcon from "@mui/icons-material/ErrorOutline";
 import CloseIcon from "@mui/icons-material/Close";
 import { DropzoneV3 } from './dropzone-v3';
+import ProgressiveImg from '../../progressive-img';
 import file_icon from '../upload-input/file.png';
 import './index.less';
 
@@ -42,7 +43,7 @@ const UploadInputV3 = ({
   id,
   parallelChunkUploads = false,
   maxConcurrentChunks = 6,
-  onError = () => {},
+  onError = () => { },
   getAllowedExtensions = null,
   getMaxSize = null,
   error,
@@ -372,7 +373,7 @@ const UploadInputV3 = ({
           {value.map((file, index) => {
             const filename = file.filename;
             const fileSize = formatFileSize(file.size);
-            let src = file?.private_url || file?.public_url;
+            let src = file?.private_url || file?.public_url || file?.file_url;
             if (src === '#') src = file?.public_url;
             // custom replace for dropbox case ( download vs raw)
             const previewSrc = src ? src.replace("?dl=0", "?raw=1") : filename;
@@ -383,12 +384,11 @@ const UploadInputV3 = ({
                 sx={fileRowSx}
               >
                 <Box sx={{ display: 'flex', alignItems: 'center', mr: 2, width: 64, height: 64, flexShrink: 0 }}>
-                  <a href={src} target="_blank" rel="noreferrer" title="Preview file">
-                    <img
-                      src={previewSrc}
+                  <a href={src} target="_blank" title="See Preview">
+                    <ProgressiveImg
                       alt={filename}
-                      onError={(e) => { e.target.src = file_icon; }}
-                      style={{ width: 70, height: 70, objectFit: 'contain', display: 'block', borderRadius: 4 }}
+                      src={previewSrc}
+                      placeholderSrc={file_icon}
                     />
                   </a>
                 </Box>
@@ -399,6 +399,7 @@ const UploadInputV3 = ({
                     href={src}
                     target="_blank"
                     rel="noreferrer"
+                    title="Preview file"
                     download
                     variant="body2"
                     fontWeight={500}

--- a/src/components/inputs/upload-input-v3/index.js
+++ b/src/components/inputs/upload-input-v3/index.js
@@ -25,6 +25,7 @@ import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import ErrorOutlineIcon from "@mui/icons-material/ErrorOutline";
 import CloseIcon from "@mui/icons-material/Close";
 import { DropzoneV3 } from './dropzone-v3';
+import file_icon from '../upload-input/file.png';
 import './index.less';
 
 const UploadInputV3 = ({
@@ -371,21 +372,37 @@ const UploadInputV3 = ({
           {value.map((file, index) => {
             const filename = file.filename;
             const fileSize = formatFileSize(file.size);
+            let src = file?.private_url || file?.public_url;
+            if (src === '#') src = file?.public_url;
+            // custom replace for dropbox case ( download vs raw)
+            const previewSrc = src ? src.replace("?dl=0", "?raw=1") : filename;
 
             return (
               <Box
                 key={`uploaded-${index}`}
                 sx={fileRowSx}
               >
-                <Box sx={{ color: 'primary.main', display: 'flex', alignItems: 'center', mr: 2, minWidth: 32 }}>
-                  <UploadFileIcon fontSize="medium" />
+                <Box sx={{ display: 'flex', alignItems: 'center', mr: 2, width: 64, height: 64, flexShrink: 0 }}>
+                  <a href={src} target="_blank" rel="noreferrer" title="Preview file">
+                    <img
+                      src={previewSrc}
+                      alt={filename}
+                      onError={(e) => { e.target.src = file_icon; }}
+                      style={{ width: 70, height: 70, objectFit: 'contain', display: 'block', borderRadius: 4 }}
+                    />
+                  </a>
                 </Box>
 
                 <Box sx={{ flex: 1, minWidth: 0 }}>
                   <Typography
+                    component="a"
+                    href={src}
+                    target="_blank"
+                    rel="noreferrer"
+                    download
                     variant="body2"
                     fontWeight={500}
-                    sx={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+                    sx={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', display: 'block', color: 'primary.main', textDecoration: 'none', '&:hover': { textDecoration: 'underline' } }}
                   >
                     {filename}
                   </Typography>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -138,5 +138,14 @@
     "total": "Total",
     "rate": "Rate",
     "action": "Action"
+  },
+  "upload_input_v3": {
+    "no_post_url": "No Post URL",
+    "upload_disabled": "Upload has been disabled by administrators.",
+    "click_upload": "Click to upload",
+    "drag_and_drop": "or drag and drop",
+    "see_preview": "See Preview",
+    "preview_file": "Preview file",
+    "complete": "Complete"
   }
 }


### PR DESCRIPTION
ref: https://app.clickup.com/t/86b9axe92

<img width="956" height="224" alt="image" src="https://github.com/user-attachments/assets/e13775ec-249b-4376-a399-840da4f8c4d9" />

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Uploaded files show image thumbnails that open in a new tab; filenames are clickable download links with download behavior.

* **Bug Fixes**
  * Previews reliably choose an available file URL and fall back when the primary link is unavailable; preview images update correctly after load errors.

* **Tests**
  * Added tests covering file preview rendering, download-link attributes, and preview error handling.

* **Documentation**
  * Added translation strings for the V3 upload input UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->