### PR TITLE
fix: replace deprecated onExited prop in SnackbarNotification

### DIFF
--- a/src/components/mui/SnackbarNotification/index.js
+++ b/src/components/mui/SnackbarNotification/index.js
@@ -72,7 +72,7 @@ const SnackbarNotification = ({
       <Snackbar
         open={open}
         onClose={onClose}
-        onExited={handleExited}
+        slotProps={{ transition: { onExited: handleExited } }}
         anchorOrigin={{ vertical: "top", horizontal: "center" }}
         autoHideDuration={NOTIFICATION_TIMEOUT}
       >


### PR DESCRIPTION
ref: https://app.clickup.com/t/9014802374/86b9y6h89

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved snackbar notification exit handling to ensure messages are properly cleared when notifications close.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->