### PR TITLE
fix: add onUploadStart prop to be called when a file upload started 

### DIFF
--- a/src/components/inputs/upload-input-v3/index.js
+++ b/src/components/inputs/upload-input-v3/index.js
@@ -40,6 +40,7 @@ const UploadInputV3 = ({
   maxFiles = 1,
   timeOut,
   onUploadComplete,
+  onUploadStart = null,
   djsConfig,
   id,
   parallelChunkUploads = false,
@@ -140,6 +141,7 @@ const UploadInputV3 = ({
 
   const handleAddedFile = useCallback((file) => {
     setUploadingFiles(prev => [...prev, { name: file.name, size: file.size, progress: 0, complete: false }]);
+    if (onUploadStart) onUploadStart(file);
   }, []);
 
   const handleUploadProgress = useCallback((file, progress) => {

--- a/src/components/inputs/upload-input-v3/index.js
+++ b/src/components/inputs/upload-input-v3/index.js
@@ -142,7 +142,7 @@ const UploadInputV3 = ({
   const handleAddedFile = useCallback((file) => {
     setUploadingFiles(prev => [...prev, { name: file.name, size: file.size, progress: 0, complete: false }]);
     if (onUploadStart) onUploadStart(file);
-  }, []);
+  }, [onUploadStart]);
 
   const handleUploadProgress = useCallback((file, progress) => {
     setUploadingFiles(prev => prev.map(f =>


### PR DESCRIPTION
ref: https://app.clickup.com/t/86b9n7p5w

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional `onUploadStart` callback to the file upload component, triggering when upload begins and enabling custom behavior independent of completion events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->