### PR TITLE
feat: add mui formik text editor

### DIFF
--- a/src/components/index.js
+++ b/src/components/index.js
@@ -97,6 +97,7 @@ export {default as MuiFormikSelectV2} from './mui/formik-inputs/mui-formik-selec
 export {default as MuiFormikSummitAddonSelect} from './mui/formik-inputs/mui-formik-summit-addon-select'
 export {default as MuiFormikSwitch} from './mui/formik-inputs/mui-formik-switch'
 export {default as MuiFormikTextField} from './mui/formik-inputs/mui-formik-textfield'
+export {default as MuiFormikTextEditor} from './mui/formik-inputs/mui-formik-text-editor'
 export {default as MuiFormikTimepicker} from './mui/formik-inputs/mui-formik-timepicker'
 export {default as MuiFormikUpload} from './mui/formik-inputs/mui-formik-upload'
 export {default as MuiCompanyInput} from './mui/formik-inputs/company-input-mui'

--- a/src/components/mui/formik-inputs/mui-formik-text-editor.js
+++ b/src/components/mui/formik-inputs/mui-formik-text-editor.js
@@ -4,15 +4,17 @@ import { InputLabel } from "@mui/material";
 import TextEditorV3 from "../../inputs/editor-input-v3";
 import { normalizeHtmlString } from "../../../utils/methods";
 
-const FormikTextEditor = ({ name, options = {}, licence, ...props }) => {
+const FormikTextEditor = ({ name, label = "", options = {}, licence, ...props }) => {
   const [field, meta, helpers] = useField(name);
   const mergedOptions = { tabIndex: 0, allowTabNavigation: true, ...options };
 
   return (
     <>
-      <InputLabel htmlFor={name}>
-        {label}
-      </InputLabel>
+      {label && (
+        <InputLabel htmlFor={name}>
+          {label}
+        </InputLabel>
+      )}
       <TextEditorV3
         id={name}
         value={field.value}

--- a/src/components/mui/formik-inputs/mui-formik-text-editor.js
+++ b/src/components/mui/formik-inputs/mui-formik-text-editor.js
@@ -1,0 +1,32 @@
+import React from "react";
+import { useField } from "formik";
+import { InputLabel } from "@mui/material";
+import TextEditorV3 from "../../inputs/editor-input-v3";
+import { normalizeHtmlString } from "../../../utils/methods";
+
+const FormikTextEditor = ({ name, options = {}, licence, ...props }) => {
+  const [field, meta, helpers] = useField(name);
+  const mergedOptions = { tabIndex: 0, allowTabNavigation: true, ...options };
+
+  return (
+    <>
+      <InputLabel htmlFor={name}>
+        {label}
+      </InputLabel>
+      <TextEditorV3
+        id={name}
+        value={field.value}
+        options={mergedOptions}
+        onChange={(e) => {
+          const stringValue = normalizeHtmlString(e.target.value);
+          helpers.setValue(stringValue);
+        }}
+        error={meta.touched && meta.error}
+        license={licence}
+        {...props}
+      />
+    </>
+  );
+};
+
+export default FormikTextEditor;

--- a/src/utils/methods.js
+++ b/src/utils/methods.js
@@ -311,3 +311,9 @@ export const empty = (value) => {
 };
 
 export const isSentryInitialized = () => typeof window !== "undefined" && !!window.SENTRY_DSN;
+
+export const normalizeHtmlString = (textInput) => {
+  if (!textInput) return "";
+  const doc = new DOMParser().parseFromString(textInput, "text/html");
+  return doc.body.textContent.trim().length === 0 ? "" : textInput;
+};

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -125,6 +125,7 @@ module.exports = {
         'components/mui/formik-inputs/summit-addon-select': './src/components/mui/formik-inputs/mui-formik-summit-addon-select.js',
         'components/mui/formik-inputs/switch': './src/components/mui/formik-inputs/mui-formik-switch.js',
         'components/mui/formik-inputs/textfield': './src/components/mui/formik-inputs/mui-formik-textfield.js',
+        'components/mui/formik-inputs/texteditor': './src/components/mui/formik-inputs/mui-formik-text-editor.js',        
         'components/mui/formik-inputs/timepicker': './src/components/mui/formik-inputs/mui-formik-timepicker.js',
         'components/mui/formik-inputs/upload': './src/components/mui/formik-inputs/mui-formik-upload.js',
         'components/mui/formik-inputs/company-input': './src/components/mui/formik-inputs/company-input-mui.js',


### PR DESCRIPTION
ref: https://app.clickup.com/t/9014802374/86b94xa4t

from https://github.com/fntechgit/sponsor-services/pull/57#discussion_r3474155581

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Formik-compatible rich text editor input with optional label support and Formik state binding, including passing validation error states to the editor.
  * Added sensible default editor options (customizable via props).
* **Bug Fixes**
  * Improved saved editor output by normalizing edited HTML so empty or whitespace-only content is stored as a blank value instead of stray HTML.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->