### PR TITLE
fix: new drag-n-drop-list component using dnd-kit lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
         "@babel/preset-flow": "^7.7.4",
         "@babel/preset-react": "^7.7.4",
         "@babel/runtime": "^7.20.7",
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@emotion/react": "^11.11.4",
         "@emotion/styled": "^11.11.5",
         "@mui/icons-material": "^6.4.3",
@@ -115,6 +118,9 @@
         "cheerio": "1.0.0-rc.10"
     },
     "peerDependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@emotion/react": "^11.11.4",
         "@emotion/styled": "^11.11.5",
         "@mui/icons-material": "^6.4.3",

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -137,3 +137,4 @@ export {MuiBaseCustomTheme} from './mui/MuiBaseCustomTheme'
 // export {default as MuiStripePayment} from './mui/StripePayment'                   // @stripe/react-stripe-js, @stripe/stripe-js
 // export {default as MuiAdditionalInput} from './mui/formik-inputs/additional-input/additional-input' // react-beautiful-dnd (via dnd-list)
 // export {default as MuiAdditionalInputList} from './mui/formik-inputs/additional-input/additional-input-list' // react-beautiful-dnd (via dnd-list)
+// export {default as MuiDragNDropList} from './mui/drag-n-drop-list'               // @dnd-kit/core @dnd-kit/sortable @dnd-kit/utilities

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -137,4 +137,4 @@ export {MuiBaseCustomTheme} from './mui/MuiBaseCustomTheme'
 // export {default as MuiStripePayment} from './mui/StripePayment'                   // @stripe/react-stripe-js, @stripe/stripe-js
 // export {default as MuiAdditionalInput} from './mui/formik-inputs/additional-input/additional-input' // react-beautiful-dnd (via dnd-list)
 // export {default as MuiAdditionalInputList} from './mui/formik-inputs/additional-input/additional-input-list' // react-beautiful-dnd (via dnd-list)
-// export {default as MuiDragNDropList} from './mui/drag-n-drop-list'               // @dnd-kit/core @dnd-kit/sortable @dnd-kit/utilities
+// export {default as MuiDragNDropList} from './mui/DragNDropList'               // @dnd-kit/core @dnd-kit/sortable @dnd-kit/utilities

--- a/src/components/mui/DragNDropList/index.js
+++ b/src/components/mui/DragNDropList/index.js
@@ -24,39 +24,12 @@ import {
 import {
   SortableContext,
   sortableKeyboardCoordinates,
-  useSortable,
   verticalListSortingStrategy,
   arrayMove
 } from "@dnd-kit/sortable";
-import { CSS } from "@dnd-kit/utilities";
 import { Box } from "@mui/material";
 
-const SortableItem = ({ id, item, index, renderItem }) => {
-  const {
-    attributes,
-    listeners,
-    setNodeRef,
-    transform,
-    transition,
-    isDragging
-  } = useSortable({ id });
-
-  return (
-    <Box
-      ref={setNodeRef}
-      style={{
-        transform: CSS.Transform.toString(transform),
-        transition: [transition, "background 0.2s ease"].filter(Boolean).join(", ")
-      }}
-      sx={{ background: isDragging ? "#f0f0f0" : "inherit" }}
-    >
-      {renderItem(item, index, {
-        isDragging,
-        dragHandleProps: { ...listeners, ...attributes }
-      })}
-    </Box>
-  );
-};
+import SortableItem from "./sortable-item";
 
 // Items without an idKey value fall back to a positional id (new-${index}).
 // Because that id is recomputed from the current index every render, after a

--- a/src/components/mui/DragNDropList/sortable-item.js
+++ b/src/components/mui/DragNDropList/sortable-item.js
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2026 OpenStack Foundation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * */
+
+import React from "react";
+import PropTypes from "prop-types";
+import {
+  useSortable,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { Box } from "@mui/material";
+
+const SortableItem = ({ id, item, index, renderItem }) => {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging
+  } = useSortable({ id });
+
+  return (
+    <Box
+      ref={setNodeRef}
+      style={{
+        transform: CSS.Transform.toString(transform),
+        transition: [transition, "background 0.2s ease"].filter(Boolean).join(", ")
+      }}
+      sx={{ background: isDragging ? "#f0f0f0" : "inherit" }}
+    >
+      {renderItem(item, index, {
+        isDragging,
+        dragHandleProps: { ...listeners, ...attributes }
+      })}
+    </Box>
+  );
+};
+
+SortableItem.propTypes = {
+  id: PropTypes.string.isRequired,
+  item: PropTypes.object.isRequired,
+  index: PropTypes.number,
+  renderItem: PropTypes.func.isRequired
+};
+
+export default SortableItem;

--- a/src/components/mui/DragNDropList/sortable-item.js
+++ b/src/components/mui/DragNDropList/sortable-item.js
@@ -34,7 +34,9 @@ const SortableItem = ({ id, item, index, renderItem }) => {
       ref={setNodeRef}
       style={{
         transform: CSS.Transform.toString(transform),
-        transition: [transition, "background 0.2s ease"].filter(Boolean).join(", ")
+        transition: [transition, "background 0.2s ease"].filter(Boolean).join(", "),
+        zIndex: isDragging ? 1 : "auto",
+        position: "relative"
       }}
       sx={{ background: isDragging ? "#f0f0f0" : "inherit" }}
     >

--- a/src/components/mui/__tests__/drag-n-drop-list.test.js
+++ b/src/components/mui/__tests__/drag-n-drop-list.test.js
@@ -1,0 +1,193 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import DragAndDropList from "../drag-n-drop-list";
+
+// Capture the onDragEnd handler so tests can simulate drags
+let triggerDragEnd;
+
+jest.mock("@dnd-kit/core", () => ({
+  DndContext: ({ children, onDragEnd }) => {
+    triggerDragEnd = onDragEnd;
+    return <>{children}</>;
+  },
+  closestCenter: jest.fn(),
+  KeyboardSensor: function KeyboardSensor() { },
+  PointerSensor: function PointerSensor() { },
+  useSensor: jest.fn(() => ({})),
+  useSensors: jest.fn(() => [])
+}));
+
+jest.mock("@dnd-kit/sortable", () => ({
+  SortableContext: ({ children }) => <>{children}</>,
+  sortableKeyboardCoordinates: jest.fn(),
+  useSortable: () => ({
+    attributes: { "data-dnd-handle": true },
+    listeners: { onPointerDown: jest.fn() },
+    setNodeRef: jest.fn(),
+    transform: null,
+    transition: null,
+    isDragging: false
+  }),
+  verticalListSortingStrategy: jest.fn(),
+  arrayMove: (arr, from, to) => {
+    const result = [...arr];
+    const [item] = result.splice(from, 1);
+    result.splice(to, 0, item);
+    return result;
+  }
+}));
+
+jest.mock("@dnd-kit/utilities", () => ({
+  CSS: { Transform: { toString: () => "" } }
+}));
+
+const mockItems = [
+  { id: 1, label: "First", order: 1 },
+  { id: 2, label: "Second", order: 2 },
+  { id: 3, label: "Third", order: 3 }
+];
+
+const renderItem = jest.fn((item, index, { isDragging, dragHandleProps }) => (
+  <div
+    key={index}
+    data-testid={`item-${index}`}
+    data-dragging={String(isDragging)}
+    {...dragHandleProps}
+  >
+    {item.label}
+  </div>
+));
+
+const renderList = (props = {}) =>
+  render(
+    <DragAndDropList
+      items={mockItems}
+      onReorder={jest.fn()}
+      renderItem={renderItem}
+      {...props}
+    />
+  );
+
+describe("DragAndDropList", () => {
+  beforeEach(() => {
+    renderItem.mockClear();
+  });
+
+  describe("rendering", () => {
+    it("renders all items via renderItem", () => {
+      renderList();
+      expect(screen.getByTestId("item-0")).toHaveTextContent("First");
+      expect(screen.getByTestId("item-1")).toHaveTextContent("Second");
+      expect(screen.getByTestId("item-2")).toHaveTextContent("Third");
+    });
+
+    it("passes isDragging and dragHandleProps to renderItem", () => {
+      renderList();
+      const [, , { isDragging, dragHandleProps }] = renderItem.mock.calls[0];
+      expect(isDragging).toBe(false);
+      expect(dragHandleProps).toHaveProperty("data-dnd-handle", true);
+      expect(dragHandleProps).toHaveProperty("onPointerDown");
+    });
+  });
+
+  describe("drag and drop", () => {
+    it("calls onReorder with correctly reordered items and updated order keys", () => {
+      const onReorder = jest.fn();
+      renderList({ onReorder });
+
+      // Drag item "1" (index 0) to position of item "3" (index 2)
+      triggerDragEnd({ active: { id: "1" }, over: { id: "3" } });
+
+      expect(onReorder).toHaveBeenCalledWith(
+        [
+          { id: 2, label: "Second", order: 1 },
+          { id: 3, label: "Third", order: 2 },
+          { id: 1, label: "First", order: 3 }
+        ],
+        expect.objectContaining({ active: { id: "1" }, over: { id: "3" } })
+      );
+    });
+
+    it("does not call onReorder when there is no drop target", () => {
+      const onReorder = jest.fn();
+      renderList({ onReorder });
+
+      triggerDragEnd({ active: { id: "1" }, over: null });
+
+      expect(onReorder).not.toHaveBeenCalled();
+    });
+
+    it("does not call onReorder when dropped on the same item", () => {
+      const onReorder = jest.fn();
+      renderList({ onReorder });
+
+      triggerDragEnd({ active: { id: "1" }, over: { id: "1" } });
+
+      expect(onReorder).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("id resolution", () => {
+    it("falls back to new-{index} for items without an id", () => {
+      const onReorder = jest.fn();
+      const items = [{ label: "A" }, { label: "B" }];
+      render(
+        <DragAndDropList
+          items={items}
+          onReorder={onReorder}
+          renderItem={renderItem}
+        />
+      );
+
+      triggerDragEnd({ active: { id: "new-0" }, over: { id: "new-1" } });
+
+      expect(onReorder).toHaveBeenCalledWith(
+        [
+          { label: "B", order: 1 },
+          { label: "A", order: 2 }
+        ],
+        expect.anything()
+      );
+    });
+
+    it("uses a custom idKey to resolve item ids", () => {
+      const onReorder = jest.fn();
+      const items = [
+        { slug: "a", label: "A", order: 1 },
+        { slug: "b", label: "B", order: 2 }
+      ];
+      render(
+        <DragAndDropList
+          items={items}
+          onReorder={onReorder}
+          renderItem={renderItem}
+          idKey="slug"
+        />
+      );
+
+      triggerDragEnd({ active: { id: "a" }, over: { id: "b" } });
+
+      expect(onReorder).toHaveBeenCalledWith(
+        [
+          { slug: "b", label: "B", order: 1 },
+          { slug: "a", label: "A", order: 2 }
+        ],
+        expect.anything()
+      );
+    });
+  });
+
+  describe("updateOrderKey", () => {
+    it("uses a custom updateOrderKey in reordered items", () => {
+      const onReorder = jest.fn();
+      renderList({ onReorder, updateOrderKey: "position" });
+
+      triggerDragEnd({ active: { id: "1" }, over: { id: "2" } });
+
+      const [reordered] = onReorder.mock.calls[0];
+      expect(reordered[0]).toHaveProperty("position", 1);
+      expect(reordered[1]).toHaveProperty("position", 2);
+    });
+  });
+});

--- a/src/components/mui/__tests__/drag-n-drop-list.test.js
+++ b/src/components/mui/__tests__/drag-n-drop-list.test.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
-import DragAndDropList from "../drag-n-drop-list";
+import DragAndDropList from "../DragNDropList";
 
 // Capture the onDragEnd handler so tests can simulate drags
 let triggerDragEnd;

--- a/src/components/mui/drag-n-drop-list.js
+++ b/src/components/mui/drag-n-drop-list.js
@@ -44,11 +44,11 @@ const SortableItem = ({ id, item, index, renderItem }) => {
   return (
     <Box
       ref={setNodeRef}
-      style={{ transform: CSS.Transform.toString(transform), transition }}
-      sx={{
-        background: isDragging ? "#f0f0f0" : "inherit",
-        transition: "background 0.2s ease"
+      style={{
+        transform: CSS.Transform.toString(transform),
+        transition: [transition, "background 0.2s ease"].filter(Boolean).join(", ")
       }}
+      sx={{ background: isDragging ? "#f0f0f0" : "inherit" }}
     >
       {renderItem(item, index, {
         isDragging,
@@ -58,6 +58,14 @@ const SortableItem = ({ id, item, index, renderItem }) => {
   );
 };
 
+// Items without an idKey value fall back to a positional id (new-${index}).
+// Because that id is recomputed from the current index every render, after a
+// reorder it identifies whatever item now occupies that slot, not the item it
+// originally pointed to - React will reuse that item's fiber instead of
+// remounting it. Harmless if renderItem is stateless/positional (e.g. Formik
+// fields bound by values[index]), but consumers relying on local/uncontrolled
+// state inside renderItem should assign a stable id (e.g. crypto.randomUUID())
+// to new items instead of leaving idKey undefined.
 const getItemId = (item, index, idKey) =>
   item[idKey] !== undefined && item[idKey] !== null
     ? String(item[idKey])

--- a/src/components/mui/drag-n-drop-list.js
+++ b/src/components/mui/drag-n-drop-list.js
@@ -1,0 +1,128 @@
+/**
+ * Copyright 2026 OpenStack Foundation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * */
+
+import React from "react";
+import PropTypes from "prop-types";
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+  arrayMove
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { Box } from "@mui/material";
+
+const SortableItem = ({ id, item, index, renderItem }) => {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging
+  } = useSortable({ id });
+
+  return (
+    <Box
+      ref={setNodeRef}
+      style={{ transform: CSS.Transform.toString(transform), transition }}
+      sx={{
+        background: isDragging ? "#f0f0f0" : "inherit",
+        transition: "background 0.2s ease"
+      }}
+    >
+      {renderItem(item, index, {
+        isDragging,
+        dragHandleProps: { ...listeners, ...attributes }
+      })}
+    </Box>
+  );
+};
+
+const getItemId = (item, index, idKey) =>
+  item[idKey] ? String(item[idKey]) : `new-${index}`;
+
+const DragNDropList = ({
+  items,
+  onReorder,
+  renderItem,
+  idKey = "id",
+  updateOrderKey = "order"
+}) => {
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  );
+
+  const handleDragEnd = ({ active, over }) => {
+    if (!over || active.id === over.id) return;
+
+    const oldIndex = items.findIndex(
+      (item, i) => getItemId(item, i, idKey) === active.id
+    );
+    const newIndex = items.findIndex(
+      (item, i) => getItemId(item, i, idKey) === over.id
+    );
+
+    const reordered = arrayMove(items, oldIndex, newIndex).map((item, i) => ({
+      ...item,
+      [updateOrderKey]: i + 1
+    }));
+
+    onReorder(reordered, { active, over });
+  };
+
+  return (
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCenter}
+      onDragEnd={handleDragEnd}
+    >
+      <SortableContext
+        items={items.map((item, i) => getItemId(item, i, idKey))}
+        strategy={verticalListSortingStrategy}
+      >
+        <Box sx={{ width: "100%" }}>
+          {items.map((item, index) => (
+            <SortableItem
+              key={getItemId(item, index, idKey)}
+              id={getItemId(item, index, idKey)}
+              item={item}
+              index={index}
+              renderItem={renderItem}
+            />
+          ))}
+        </Box>
+      </SortableContext>
+    </DndContext>
+  );
+};
+
+DragNDropList.propTypes = {
+  items: PropTypes.array.isRequired,
+  onReorder: PropTypes.func.isRequired,
+  renderItem: PropTypes.func.isRequired,
+  idKey: PropTypes.string,
+  updateOrderKey: PropTypes.string
+};
+
+export default DragNDropList;

--- a/src/components/mui/drag-n-drop-list.js
+++ b/src/components/mui/drag-n-drop-list.js
@@ -59,7 +59,9 @@ const SortableItem = ({ id, item, index, renderItem }) => {
 };
 
 const getItemId = (item, index, idKey) =>
-  item[idKey] ? String(item[idKey]) : `new-${index}`;
+  item[idKey] !== undefined && item[idKey] !== null
+    ? String(item[idKey])
+    : `new-${index}`;
 
 const DragNDropList = ({
   items,
@@ -82,6 +84,8 @@ const DragNDropList = ({
     const newIndex = items.findIndex(
       (item, i) => getItemId(item, i, idKey) === over.id
     );
+
+    if (oldIndex === -1 || newIndex === -1) return;
 
     const reordered = arrayMove(items, oldIndex, newIndex).map((item, i) => ({
       ...item,

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -87,7 +87,7 @@ module.exports = {
         'components/mui/confirm-dialog': './src/components/mui/confirm-dialog.js',
         'components/mui/custom-alert': './src/components/mui/CustomAlert/index.js',
         'components/mui/dnd-list': './src/components/mui/dnd-list.js',
-        'components/mui/drag-n-drop-list': './src/components/mui/drag-n-drop-list.js',
+        'components/mui/drag-n-drop-list': './src/components/mui/DragNDropList/index.js',
         'components/mui/dropdown-checkbox': './src/components/mui/dropdown-checkbox.js',
         'components/mui/dropdown': './src/components/mui/Dropdown',
         'components/mui/toggle-buttons': './src/components/mui/ToggleButtons',

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -87,6 +87,7 @@ module.exports = {
         'components/mui/confirm-dialog': './src/components/mui/confirm-dialog.js',
         'components/mui/custom-alert': './src/components/mui/CustomAlert/index.js',
         'components/mui/dnd-list': './src/components/mui/dnd-list.js',
+        'components/mui/drag-n-drop-list': './src/components/mui/drag-n-drop-list.js',
         'components/mui/dropdown-checkbox': './src/components/mui/dropdown-checkbox.js',
         'components/mui/dropdown': './src/components/mui/Dropdown',
         'components/mui/toggle-buttons': './src/components/mui/ToggleButtons',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1051,6 +1051,37 @@
   resolved "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz"
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
+"@dnd-kit/accessibility@^3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz#3b4202bd6bb370a0730f6734867785919beac6af"
+  integrity sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==
+  dependencies:
+    tslib "^2.0.0"
+
+"@dnd-kit/core@^6.3.1":
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/core/-/core-6.3.1.tgz#4c36406a62c7baac499726f899935f93f0e6d003"
+  integrity sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==
+  dependencies:
+    "@dnd-kit/accessibility" "^3.1.1"
+    "@dnd-kit/utilities" "^3.2.2"
+    tslib "^2.0.0"
+
+"@dnd-kit/sortable@^10.0.0":
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/sortable/-/sortable-10.0.0.tgz#1f9382b90d835cd5c65d92824fa9dafb78c4c3e8"
+  integrity sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==
+  dependencies:
+    "@dnd-kit/utilities" "^3.2.2"
+    tslib "^2.0.0"
+
+"@dnd-kit/utilities@^3.2.2":
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/utilities/-/utilities-3.2.2.tgz#5a32b6af356dc5f74d61b37d6f7129a4040ced7b"
+  integrity sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==
+  dependencies:
+    tslib "^2.0.0"
+
 "@emotion/babel-plugin@^11.13.5":
   version "11.13.5"
   resolved "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz"


### PR DESCRIPTION
ref: https://github.com/fntechgit/sponsor-services/pull/57

from https://github.com/fntechgit/sponsor-services/pull/57#discussion_r3505871793

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new drag-and-drop list component for MUI-based UIs, letting users reorder items visually.
  * Supports custom item rendering, drag handles, and automatic order updates after reordering.
  * Added a bundled entry so the component is available in builds.

* **Tests**
  * Added coverage for rendering, drag-and-drop reordering, missing IDs, custom ID fields, and order updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->